### PR TITLE
Make service name to match repo name (for CI automation)

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
 - hash: 28e6b04108dae248c07b321df44d41bf7bcbdf7d
-  name: core
+  name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/

--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
 - hash: 8d7dd9f23b93025c28f1ef462e46303b4203fecb
-  name: f8tenant
+  name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/

--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
 - hash: bfc5a791a6ccc3387d408f3fdca8066daa1ff3b8
-  name: f8ui
+  name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8io/fabric8-ui/

--- a/dsaas-services/www.openshift.io.yaml
+++ b/dsaas-services/www.openshift.io.yaml
@@ -1,5 +1,5 @@
 services:
 - hash: e615a1ea792a3ffe6099d2a2b97abf6a0ba0c8f5
-  name: www.openshift.io
+  name: openshift.io
   path: /openshift/www.openshift.io.app.yaml
   url: https://github.com/openshiftio/openshift.io

--- a/keycloak-services/keycloak.yaml
+++ b/keycloak-services/keycloak.yaml
@@ -1,5 +1,5 @@
 services:
 - hash: ac1aca8fa18267c3bc5aea910b8023cddf03f63c
-  name: keycloak
+  name: keycloak-deployment
   path: /openshift/keycloak.app.yaml
   url: https://github.com/fabric8io/keycloak-deployment


### PR DESCRIPTION
To make saasherder easily usable in CI jobs, service names now match repo names - this allows us to use repo name as a service identifier without adding another (redundant) value in CI