### PR TITLE
Update to recent fabric8-wit master

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0647db716e7d6997992969e4f67fb82419e6dc3e
+- hash: f416aacb9575def4fe197f64160632c52764cb3c
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
* docker-compose file uses correct directory config.yaml https://github.com/fabric8-services/fabric8-wit/pull/1505
* Add DataConflictError & return HTTP 409 when creating duplicate areas https://github.com/fabric8-services/fabric8-wit/pull/1509
* Query language for filter https://github.com/fabric8-services/fabric8-wit/pull/1449