### PR TITLE
Use 'master' hash (latest commit) for f8-docs deployments

### DIFF
--- a/dsaas-services/f8-docs.yaml
+++ b/dsaas-services/f8-docs.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 35aa4a02a632dbd93738e33dd9ecf8f6c525cc5c
+- hash: master
   name: fabric8-online-docs
   path: /openshift/fabric8-online-docs.app.yaml
   url: https://github.com/fabric8io/fabric8-online-docs


### PR DESCRIPTION
f8-docs wants the latest commits to go to prod for a streamlined workflow.