### PR TITLE
Revert "Use 'master' hash (latest commit) for f8-docs deployments"

### DIFF
--- a/dsaas-services/f8-docs.yaml
+++ b/dsaas-services/f8-docs.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: master
+- hash: 35aa4a02a632dbd93738e33dd9ecf8f6c525cc5c
   name: fabric8-online-docs
   path: /openshift/fabric8-online-docs.app.yaml
   url: https://github.com/fabric8io/fabric8-online-docs


### PR DESCRIPTION
Reverts openshiftio/saas-openshiftio#342

Having 'master' as hash would enable the latest image to be deployed, but for the manual promote-to-prod step, the CI gets kicked off on a PR being merged to master on saas-openshiftio. Hardcoding 'master' into the hash will remove the need for the PR and thus the CI will not be kicked off, which is not what was intended.