### PR TITLE
Bump fabric8-wit / core to 9709b5cfd

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: c6fc618c8927135b21e8912b64f105a4b4bb8d8e
+- hash: 9709b5cfdcf7a780463d9412e905298bcf35cebc
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
These are the changes that go in with this version bump:

Generated from `git log c6fc618c8927135b21e8912b64f105a4b4bb8d8e...HEAD --reverse`.

## Remoteworkitem Tracker Refactor (https://github.com/fabric8-services/fabric8-wit/issues/1722)

## Refactoring of child iterations tests using TestFixtures. (https://github.com/fabric8-services/fabric8-wit/issues/1666)
    
Use TestFixtures in child iterations tests.

## repalce OwnerId by OwnerID (https://github.com/fabric8-services/fabric8-wit/issues/1731)
    
rename space attribute from `OwnerId` to `OwnerID`

## Iteration child tests using golden files (https://github.com/fabric8-services/fabric8-wit/issues/1689)
    
Added golden files for unauthorized, bad request, forbidden, conflict etc.

## representation of "empty" labels & assignees (https://github.com/fabric8-services/fabric8-wit/issues/1699)
    
When a new work item is created without lables, then labels data is
stored as "NULL" in the database. When the same work item is update
without labels, it store "[]" as the value in the database. This
behaviour is same for assignees as well.

If the value is empty, the entire key/value pair will be removed.

Fixes https://openshift.io/openshiftio/openshiftio/plan/detail/1517

## Remove unknown link types and link categories (https://github.com/fabric8-services/fabric8-wit/issues/1730)
    
The following link types exist in the current production database but they are not known to the code and therefore we re-assign all links associated to those link types with their appropriate *known* link type and later remove these unknown link types.

aad2a4ad-d601-4104-9804-2c977ca2e0c1
355b647b-adc5-46b3-b297-cc54bc0554e6
7479a9b9-8607-46fa-9535-d448fa8768ab

There also exist two unknown link categories [see here](https://api.openshift.io/api/workitemlinkcategories):

04b89525-84ff-406c-8e18-d990936bdb74
6329fbb3-399b-4a78-ae3b-6a6faa8b1084

Those will be removed as well.

After this PR is merged, we should only have three link types to choose from in the UI and the duplicates should be gone as well. Without the duplicate entries of `parent of` and `child of` you then can no longer link a WI to two parents. Without this PR you still can link a child WI to two parent WIs when you choose from two different link types.

To double check, what link types exist, try this command:

```sh
curl --silent https://api.openshift.io/api/spaces/020f756e-b51a-4b43-b113-45cec16b9ce9/workitemlinktypes \
| jq ".data[] | .id, .attributes.name"
```

It should output the id and name of each link  type in the current production database:
```json
"aad2a4ad-d601-4104-9804-2c977ca2e0c1"
"Bug blocker"
"355b647b-adc5-46b3-b297-cc54bc0554e6"
"Related planner item"
"7479a9b9-8607-46fa-9535-d448fa8768ab"
"Parent child item"
"2cea3c79-3b79-423b-90f4-1e59174c8f43"
"Bug blocker"
"9b631885-83b1-4abb-a340-3a9ede8493fa"
"Related planner item"
"25c326a7-6d03-4f5a-b23b-86a9ee4171e9"
"Parent child item"
```

In  https://github.com/fabric8-services/fabric8-wit/commit/90c595ea I have introduced fixed IDs for link types and link categories and that must have been the time when the old ones weren't deleted.

As part of this PR I've replaced many of the `panic` calls within the migration tests with normal test failures. I've also wrapped errors and added filenames of executed SQL files to the error output to increase *debuggability* (is that a word?).

This relates to https://github.com/fabric8-services/fabric8-wit/issues/1729  and https://github.com/fabric8-ui/fabric8-planner/pull/2291#issuecomment-339278719