### PR TITLE
Add cluster to datamodel, endpoint for svc account token

### DIFF
--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e2cc454e80e41c9f591c28a8f16b5a6b9e92f729
+- hash: d31f23f03093e6e0b862bdcb57eea9e32c90d951
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/


### PR DESCRIPTION
Issue 178 service account authentication docs (#187)
Add cluster info to user data model (#164)
fix filesystem permissions (#185) 
Rename auth Service Account to 'fabric8-auth' (#183)
Add metrics endpoint consumed by local PCP (#184)
Service Account token issuance (login) endpoint (#169)
Clean up test identity in account linking tests (#181)