### PR TITLE
Manual tenant update to e5657b1

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2871a6c61e4ac7a4ae05f4f915db78c7f62a43ca
+- hash: e5657b14c9844c9ebb533398aa20fd7158969a9f
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
Jenkins Pipeline does not handle Failed Centos-CI build which is manually retriggered.

Centos-CI failed due to failure on Fedora infra due to Fedora 27 release.