### PR TITLE
Add fabric8-admin-proxy deployment description

### DIFF
--- a/dsaas-services/f8-admin-proxy.yaml
+++ b/dsaas-services/f8-admin-proxy.yaml
@@ -1,0 +1,5 @@
+services:
+- hash: 
+  name: fabric8-admin-proxy
+  path: /openshift/OpenShiftTemplate.yml
+  url: https://github.com/fabric8-services/fabric8-admin-proxy/


### PR DESCRIPTION
Used to expose internal services externally via auth layer