### PR TITLE
Bump core to 72789544a3f in prod

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 8a65bcbc7bb2efaaa8c56337d076a3e9e0b19179
+- hash: 72789544a3f75cb6a805531ec09ce282b649b445
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
The following is generated from `git fetch upstream && git log 8a65bcbc7bb2efaaa8c56337d076a3e9e0b19179...upstream/master --reverse`

## Parameterised the isServiceAccount(..) method (https://github.com/fabric8-services/fabric8-wit/issues/1767)

* Allows only "fabric8-auth" service account for AUTH to talk to WIT, removing support for "auth" service account
* Modified isServiceAccount(ctx) method to accept other services and not just "fabric8-auth" by adding an argument for service name

fixes https://github.com/fabric8-services/fabric8-wit/issues/1764 and https://github.com/fabric8-services/fabric8-wit/issues/1763

## Local core & planner OpenShift development using Kedge (https://github.com/fabric8-services/fabric8-wit/issues/1741)

Allow UI & backend developer to run respective dependencies in the `minishift` using `kedge`

## Improve TestSearchController.TestUpdateWorkItem() test (https://github.com/fabric8-services/fabric8-wit/issues/1773)

Before the test didn't filter by space ID. I should say, it specified a space ID in their call to `test.ShowSearchOK()` but that `spaceID` is  internally ignored if a filter expression is also given.

I've created more than one work item per test and changed the query to an `AND` filter which includes the old query and the new *by-space-query*.

Some supporting changes I've done are these:

* Added test fixture customization functions:
  * `SetWorkItemField` this lets a user set any field in a work item by giving its key as the first argument. We validated the input based on the work item's type definition and return an error if a wrong argument is passed.
* Added test fixture query functions:
  * `WorkItemTypeByID`

## UUID agnostic golden file comparison replaces real UUIDs during update (https://github.com/fabric8-services/fabric8-wit/issues/1774)

When you update a golden file using `go test -update` it will contain a set of new random UUIDs.

Those new UUIDs appear as changes inside a commit if you just do `git add myGoldenFile.json`. This clutters the commit and hides the real change that might have appeared in your commit.

I want you to be able to focus on the real changes to the API and not on some random UUIDs.

That is why a golden file that is generated with `controller.compareWithGoldenUUIDAgnostic()` will now have all UUIDs replaced with  "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", ..., "00000000-0000-0000-0000-00000000000N" and so on.

The next time you update your golden files will be much easier.

## Enabling optional fields in User/Identity data-model to accept empty strings

* Made changes such that gorm can update fields with blank values as well
It used to treat them as not-changed before

Fixes https://github.com/fabric8-services/fabric8-wit/issues/1771

## Filter by title (https://github.com/fabric8-services/fabric8-wit/issues/1748)

Fixes https://openshift.io/openshiftio/openshiftio/plan/detail/1558

Example usage:
```
{"title":{"$SUBSTR":"hello"}}
```

## Add "workItemLinks" relationship on work item response (https://github.com/fabric8-services/fabric8-wit/issues/1775)

I've created a long missing `related` link to a new `workItemLinks` relationship in the work item response.

With this change, the UI no longer needs to construct the URL to fetch links for a work item manually.