### PR TITLE
Bump core to 9886105d559e in prod

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 72789544a3f75cb6a805531ec09ce282b649b445
+- hash: 9886105d559e1ea7647585857bc330e5c99b1058
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
The following is generated from `git fetch upstream && git log 72789544a3f75cb6a805531ec09ce282b649b445...upstream/master --reverse`

## Explain what WIT is (https://github.com/fabric8-services/fabric8-wit/issues/1776)
    
Improve WIT description.
Always mention the elephant in the room; especially when its pink and weighs 18T !


## Rework controller link tests (https://github.com/fabric8-services/fabric8-wit/issues/1769)
    
Most of the change is due to golden files being added.
    
Apart from that I've removed all the ugliness of work item link test setup and have grouped tests into sub-tests under their proper parent test (e.g. `TestCreate`, `TestList`, `TestShow`, `TestUpdate`, `TestDelete`).
    
In responses for work item links I've removed the work item link category from the included section as well.

## Some cleanups suggested by golint (https://github.com/fabric8-services/fabric8-wit/issues/1778)
    
* Fix: don't use underscored in Go names

  search/search_repository.go:34:2: don't use underscores in Go names; const Q_EQ should be QEQ
  search/search_repository.go:35:2: don't use underscores in Go names; const Q_NE should be QNE
  search/search_repository.go:36:2: don't use ALL_CAPS in Go names; use CamelCase
  search/search_repository.go:37:2: don't use underscores in Go names; const Q_OR should be QOR
  search/search_repository.go:38:2: don't use ALL_CAPS in Go names; use CamelCase
  search/search_repository.go:39:2: don't use underscores in Go names; const Q_IN should be QIN

* Rename auth.AuthServiceConfiguration to auth.ServiceConfiguration

    auth/resource.go:30:6: type name will be used as auth.AuthServiceConfiguration by other packages, and that stutters; consider calling this ServiceConfiguration

* Synchonize receiver name in codebase repo

    codebase/codebase.go:176:1: receiver name r should be consistent with previous receiver name m for GormCodebaseRepository


* Renamed che.CheStarterError to che.StarterError

    codebase/che/client.go:440:6: type name will be used as che.CheStarterError by other packages, and that stutters; consider calling this StarterError

* Renamed che.CheServerStateResponse to che.ServerStateResponse

    codebase/che/client.go:457:6: type name will be used as che.CheServerStateResponse by other packages, and that stutters; consider calling this ServerStateResponse

*  configuration pkg: renamed GetRegistry to Get and NewRegistry to New

    configuration/configuration.go:106:6: type name will be used as configuration.ConfigurationData by other packages, and that stutters; consider calling this Data

* Fix package comment for goamiddleware

    goamiddleware/doc.go:1:1: package comment should be of the form "Package goamiddleware ..."

* Renamed targetUrl to targetURL

    rest/proxy/proxy.go:43:2: var targetUrl should be targetURL

* Avoid dot import

    query/simple/simple_parser.go:9:2: should not use dot imports

* Simpler array init

    remoteworkitem/remoteworkitem.go:133:2: can probably use "var result []string" instead

* Simplify array init

    space/space.go:141:2: can probably use "var result []Space" instead

* Simplify error creation

    token/token.go:161:16: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)

## Temporary redirect instead of permanent one for fetching WI by number (https://github.com/fabric8-services/fabric8-wit/issues/1786)
    
see https://github.com/openshiftio/openshift.io/issues/1219
see https://openshift.io/openshiftio/openshiftio/plan/detail/1672