### PR TITLE
Update Keycloak

### DIFF
--- a/keycloak-services/keycloak.yaml
+++ b/keycloak-services/keycloak.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 5302de55f06d5d82bdd7ca7c076f7a594f92f712
+- hash: 227bd7c3e03687f5de4014556219ae0623eef06f
   name: keycloak-deployment
   path: /openshift/keycloak.app.yaml
   url: https://github.com/fabric8-services/keycloak-deployment


### PR DESCRIPTION
Fix for "Requested broker account linking, but current session is no longer valid" error during user re-login