### PR TITLE
Bump core to 0bb47c1ebfd in prod

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 59652c3a17438a1f7a98de71d554dd3a72bf4d89
+- hash: 0bb47c1ebfd71c023ec3795696520bf6c6a06226
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
The following log was generated from `git fetch upstream && git log 59652c3a17438a1f7a98de71d554dd3a72bf4d89...upstream/master --reverse`

## Isolated setup & ability to use tags from snapshots for WIT & AUTH (https://github.com/fabric8-services/fabric8-wit/issues/1781)
    
Isolated setup for running planner services on OpenShift. Created a new directory and moved related make targets to the same along with Kedge files and check_hosts script.
Added a README for instructions.
Images can use tags so that we can run any WIT aginst any AUTH.

## Redesign work item type group API (https://github.com/fabric8-services/fabric8-wit/issues/1791)

* Fixes https://github.com/fabric8-services/fabric8-wit/issues/1790
* Added a show method for each work item type group
* Reworked the list method
* Golden files included for all tests
* All API responses conform to JSONAPI now
* Typegroup was moved inside the workitem package because otherwise we
would have a dependency cycle

## Added SpaceTemplate relation to work item type group response (https://github.com/fabric8-services/fabric8-wit/issues/1793)

## Remove unused jenkins dir (https://github.com/fabric8-services/fabric8-wit/issues/1795)

This removes the `jenkins` directory that we haven't been using for over a year. In fact it wasn't used for long at all and it stinks ;)

## API to update labels (https://github.com/fabric8-services/fabric8-wit/issues/1638)

- `PATCH` method can be used for update.
- API end point: `/api/spaces/{Space-ID}/labels/{Label-ID}`

Fixes https://github.com/fabric8-services/fabric8-wit/issues/1624

## Revert label ID attribute (https://github.com/fabric8-services/fabric8-wit/issues/1799)

The UI code was broken due the change in  https://github.com/fabric8-services/fabric8-wit/issues/1638

## Add "show-in-sidebar" to work item type group response (https://github.com/fabric8-services/fabric8-wit/issues/1800)

Fixes https://openshift.io/openshiftio/openshiftio/plan/detail/1752

## Update iteration parent (https://github.com/fabric8-services/fabric8-wit/issues/1770)

Allow user to update parent of an iteration.

## Fixes to minishift/README.md (https://github.com/fabric8-services/fabric8-wit/issues/1792)

Fix development setup on MiniShift, added README.

## Add next/prev group relationship to wit group (https://github.com/fabric8-services/fabric8-wit/issues/1797)

In order to help a client navigate around the work item type groups I've added a relationship to the previous and next work item type group (if any). When only looking at one work item type group (not at the list), this should help to get the next or previous one. Also this should help when adding a guided quick add.

## Work item type group as a search query condition (https://github.com/fabric8-services/fabric8-wit/issues/1779)

## Solution

I've introduced a `"$WITGROUP"` query parameter which internally gets translated from simple

```
$WITGROUP = y
$WITGROUP != y
```
expressions into

```
Type IN (y1, y2, y3, ... ,yn)
Type NOT IN (y1, y2, y3, ... ,yn)
```

expressions where `yi` represents the `i`-th work item type associated with the work item type group `y`.

### Example

```
$WITGROUP = "Experiences"
```
translates to

```
Type IN (Experience, Value Proposition)
```

Currently the work item hierarchy can be searched for on top-level of the query as well as in a deeply nested place in the query.

This relates to [Guided Type Hierarchy as a Search Query Condition [7]](https://openshift.io/openshiftio/openshiftio/plan/detail/1717)

## Made show action for WIT group standalone (https://github.com/fabric8-services/fabric8-wit/issues/1802)

Before you could view a WIT group by hitting

```
/api/spacetemplates/<SPACE_TEMPLATE_ID>/workitemtypegroups/<WIT_GROUP_ID>
```

That level of nesting should not be needed becaus the `<WIT_GROUP_ID>` is good enough to filter on a work item type group. Now you can view a group with

```
/api/workitemtypegroups/<WIT_GROUP_ID>
```

The *list* action is still located under the space template endpoint:

```
/api/spacetemplates/<SPACE_TEMPLATE_ID>/workitemtypegroups
```

## Fix link to WIT groups in space (https://github.com/fabric8-services/fabric8-wit/issues/1804)

And remove an obsolete and unused links entry for WIT groups.

Previously the link to list all work item type groups used to be

```
http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/
```

Now it is

```
http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups
```

NOTICE: the missing trailing `/`.

## Fixup list WIT groups: ctrl not mounted (https://github.com/fabric8-services/fabric8-wit/issues/1805)

I forgot to mount the new WIT groups controller that has the "list" action in it.