### PR TITLE
Update Auth

### DIFF
--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 7442d4b9dc060407766e25bf44f0867cf7285ba8
+- hash: ea2ef78319a4e7ad5d3986f27b6e3ea184259437
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/


### PR DESCRIPTION
Fix tests for /api/user controller (#235)
Endpoints for supporting oauth2.0 friendly login (#210)
Update existing Keycloak users when registering new users (#231)
ISSUE-71 initial endpoint implementation for resource registration (#94)
Use test with no coverage by default (#220)
Get rid of configuration dependency in logger (#221)
Clean up Readme (#219)
Build and deploy auth service in minishift (#207)
Add option to pull externally linked account details (#218)
Add constraint for allowed user search query string (#217)
Fetch user's username for linked Github/OpenShiftOnline account (#214)
Remove unused jenkins files (#215)