### PR TITLE
Bump core to 088ef038442b963b4acb2c950c6724afaf079d5b

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0bb47c1ebfd71c023ec3795696520bf6c6a06226
+- hash: 088ef038442b963b4acb2c950c6724afaf079d5b
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
Stats on the change generated by `git diff 0bb47c1ebfd71c023ec3795696520bf6c6a06226...upstream/master --reverse --stat | tail -n1`:

```
165 files changed, 2741 insertions(+), 1751 deletions(-)
```

The following log was generated from `git log 0bb47c1ebfd71c023ec3795696520bf6c6a06226...upstream/master --reverse`:

----

## WIP: Improve API doc for iteration (https://github.com/fabric8-services/fabric8-wit/issues/1806)

### Problem

Based on a discussion between Ruchir and me, we've discovered that our core API is currently hard to use because we're missing real world examples and a good swagger documentation.

The most important part to get fixes is to tell the user which fields in a resource payload are **MANDATORY** for what kind of action.

For example, there's no documentation on what attributes or fields are required when creating or updating an iteration.

### Proposal

#### Change generated swagger documentation

In order to address this, I've created a way to mark the description of fields to be mandatory.

Before this was the description for the the `name` attribute of an iteration.

```go
a.Attribute("name", d.String, "The iteration name", nameValidationFunction)
```

You have to understand that we re-use the whole iteration construct during all of the supported actions (e.g. create, update, delete, etc.). That means we cannot simply mark it as mandatory once and for all. But instead we can do something like this:

```go
a.Attribute("name", d.String, mandatoryOnCreate("The iteration name"), nameValidationFunction)
```

#### Real world examples

Instead of maintaining a set of real world example payloads that might run out of date we might as well just dump test requests.

In our tests we used to only have golden files for responses but not for the actual requests. Now I've added the requests as well. Just by looking at this file for example, it should be possible to find out what attributes are required to create an iteration:

**controller/test-files/iteration/create/ok_create_child_ID_paylod.req.payload.golden**:
```json
{
    "data": {
    "attributes": {
        "description": "Some description",
        "endAt": "2016-11-25T15:08:41Z",
        "name": "Sprint #21",
        "startAt": "2016-11-04T15:08:41Z",
        "user_active": false
    },
    "id": "00000000-0000-0000-0000-000000000001",
    "type": "iterations"
    }
}
```

Now, this might not be the bare minimum you need to specify but if you now take a quick look at the new swagger portion, you can find out really easy what is needed.

http://swagger.goa.design/?url=github.com%2Ffabric8-services%2Ffabric8-wit%2Fdesign#!/iteration/iteration_create_child

## TestFixture: Added WorkItemLinksCustom recipe and WorkItemByID query (https://github.com/fabric8-services/fabric8-wit/issues/1812)

## Use require.Error and require.NoError (https://github.com/fabric8-services/fabric8-wit/issues/1813)

Instead of just checking for Nil or NotNil use a function that properly displays the error.

Thank you @xcoulon for showing me these functions.

* Replace `require.Nil(<T>, err` with `require.NoError(<T>, err`

This was used to make the change:

find . -path ./vendor -prune -o -name '*.go' -print -exec sed -i -e 's/require\.Nil(\(.*\), err/require\.NoError(\1, err/g' {} \;

* Replace `assert.Nil(<T>, err` with `require.NoError(<T>, err`

This was used to make the change:

find . -path ./vendor -prune -o -name '*.go' -print -exec sed -i -e 's/assert\.Nil(\(.*\), err/require\.NoError(\1, err/g' {} \;

* Replace `require.NotNil(<T>, err` with `require.Error(<T>, err`

This was used to make the change:

find . -path ./vendor -prune -o -name '*.go' -print -exec sed -i -e 's/require\.NotNil(\(.*\), err/require\.Error(\1, err/g' {} \;

## Query Types as a Search Query Setting (https://github.com/fabric8-services/fabric8-wit/issues/1801)

Introduce query options with key as `$OPTS`

e.g.,

`{"$OPTS": {"tree-view": true, "parent-exists": true}}`

Fixes https://openshift.io/openshiftio/openshiftio/plan/detail/1716

## update minishift/README.md (https://github.com/fabric8-services/fabric8-wit/issues/1815)

update makefile and readme

## Allow collaborator to create & update iterations. (https://github.com/fabric8-services/fabric8-wit/issues/1783)

A collaborator can create & update iterations in that space.

## link to minishift docs (https://github.com/fabric8-services/fabric8-wit/issues/1819)

## Separate Guided Child creation and Browsing (https://github.com/fabric8-services/fabric8-wit/issues/1820)

The execution group shall also contain the Bug and the Feature WIT.
That effectively means that a WIT does appear in more than one group
now. The group should now only be used to do the viewing part and not
the guided child creation part.

For the guided child creation I have modified the work item type
response to include a new relationship called `guidedChildTypes`.
We must this relationship when proposing child types to the user.

Currently this is all hardcoded and only available for the
system-defined work item types in order to get going UI-wise.

## Use transaction when creating a link (https://github.com/fabric8-services/fabric8-wit/issues/1821)

## Link updates (https://github.com/fabric8-services/fabric8-wit/issues/1822)

Removes **Update**/**Save** method of work item link repository and all controllers.

The only permitted actions to a link once created are:
    * **delete**
    * **show**
    * **list**

In order to mimic the **update** behavior you have to **delete and recreate** a link with different settings (e.g. with a different link type). This is needed in order for us to maintain a valid *topology*.

Also the `Create` method has been removed from the `/api/workitems/<ID>/relationships/links` endpoint. Only the `List` method remains for this endpoint.

## update logrus version (https://github.com/fabric8-services/fabric8-wit/issues/1825)

Updated to 1.0.4 (specified hash)

## increment prometheus/common to fix logrus (https://github.com/fabric8-services/fabric8-wit/issues/1826)

Path to Import path changed from `github.com/Sirupsen/logrus` to `github.com/sirupsen/logrus`

## include kingpin - a dependency for prometheus (https://github.com/fabric8-services/fabric8-wit/issues/1827)

auto updated other deps

## introduce "ptr" package for on-the-fly pointer values (https://github.com/fabric8-services/fabric8-wit/issues/1830)

Package `ptr` provides functions to create on the fly pointer values for some built-in types. This might seem stupid at first but in our codebase we have a lot of places in which we just need to create variable just to get the pointer. That clutters the code a lot and causes distraction. Most of the time those strings are just throw-away constants and the pointer "is not really important later".

I've also changed the function `newCreateChildAreaPayload` to accept a `string` rather than a `*string` because in 99% of the time the string is not nil.

## repository.CheckExists now accepts a uuid.UUID instead of a string (https://github.com/fabric8-services/fabric8-wit/issues/1831)

it accepted `string` before because the tracker query repo was using string. I've changed that to have a standalone CheckExists function: https://github.com/fabric8-services/fabric8-wit/pull/1831/files#diff-cbc645207e5431802cb2869a92ce9197L33

## auto-create dir to write golden file to (https://github.com/fabric8-services/fabric8-wit/issues/1832)

When using the `-update` switch to `go test` this will auto-create the directory and potential parent directories in order for you to write golden test to. Just use
```go
compareWithGoldenUUIDAgnostic(t, filepath.Join("foo", "bar", "foobar.golden.json"), payload)
```
and `/foo/bar` will be created with `0777` permissions.

## Moved non-whitebox test for "search" pkg to blackbox test (https://github.com/fabric8-services/fabric8-wit/issues/1834)

The nice side effect of this change is that the `search` package is no longer polluted because it no longer imports the `testfixture` package. Only the `search_test` package still includes the `testfixture` package now.

## rename golden files for links and add req payload for create action (https://github.com/fabric8-services/fabric8-wit/issues/1833)

I've renamed the golden files for work item links to include `res` for "response" and `req` for "request". Also I've added a request payload for link creation that should help document what's needed in order to create a link.

## Remove not/existing/folder/file.golden.json on test end (https://github.com/fabric8-services/fabric8-wit/issues/1835)

## Added simplification for creating link chains in test (https://github.com/fabric8-services/fabric8-wit/issues/1837)

Here's a much easier way to create link trees without the hassle of big switch statements. I've used two link chains in order to demonstrate that you can create disjoint links as well.

```go
chain1 := tf.LinkChain("A", "B", "C")
chain2 := tf.LinkChain("D", "E", "F", "G")

fxt := tf.NewTestFixture(t, s.DB,
        tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyDependency)),
        tf.WorkItems(7, tf.SetWorkItemTitles("A", "B", "C", "D", "E", "F", "G")),
        tf.WorkItemLinksCustom(5, tf.BuildLinks(append(chain1, chain2...)...)),
)
```

Before you would have to write this (which is still supported):

```go
fxt = tf.NewTestFixture(t, s.DB,
        tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyDependency)),
        tf.WorkItems(7, tf.SetWorkItemTitles("A", "B", "C", "D", "E", "F", "G")),
        tf.WorkItemLinksCustom(5, func(fxt *tf.TestFixture, idx int) error {
                l := fxt.WorkItemLinks[idx]
                switch idx {
                case 0:
                        l.SourceID = fxt.WorkItemByTitle("A").ID
                        l.TargetID = fxt.WorkItemByTitle("B").ID
                case 1:
                        l.SourceID = fxt.WorkItemByTitle("B").ID
                        l.TargetID = fxt.WorkItemByTitle("C").ID
                case 2:
                        l.SourceID = fxt.WorkItemByTitle("D").ID
                        l.TargetID = fxt.WorkItemByTitle("E").ID
                case 3:
                        l.SourceID = fxt.WorkItemByTitle("E").ID
                        l.TargetID = fxt.WorkItemByTitle("F").ID
                case 4:
                        l.SourceID = fxt.WorkItemByTitle("F").ID
                        l.TargetID = fxt.WorkItemByTitle("G").ID
                }
                return nil
        }),
)
```

## endpoint in WIT to proxy requests to toggles-service (#OSIO1796) (https://github.com/fabric8-services/fabric8-wit/issues/1836)

* endpoint in WIT to proxy requests to toggles-service (#OSIO1796)

Just using the `proxy.RouteHTTP()` function to forward the request
to the `toggles-service`.
Also, include the new `F8_TOGGLES_SERVICEURL` env variable in the
OpenShift template

## endpoint in WIT to proxy requests to toggles-service - fix example ConfigMap (#OSIO1796) (https://github.com/fabric8-services/fabric8-wit/issues/1838)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

## remove unwanted golden file (https://github.com/fabric8-services/fabric8-wit/issues/1839) (https://github.com/fabric8-services/fabric8-wit/issues/1840)

also, include full path in .gitignore to avoid committing it again

fixes https://github.com/fabric8-services/fabric8-wit/issues/1839

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
