### PR TITLE
WIP: Bump core to 1a82226598d2

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1a82226598d22845ea7547732f050658054d5251
+- hash: fb8d5cd61742a3d05742ee8e848c17c46782a63f
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/

--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 994e3aafe2a3d8d24c472bf21dcb15627e429fc2
+- hash: 1a82226598d22845ea7547732f050658054d5251
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
Stats on the change generated by `git diff 994e3aafe2a3d8d24c472bf21dcb15627e429fc2...upstream/master --reverse --stat | tail -n1`:

```
 56 files changed, 3767 insertions(+), 295 deletions(-)
```

The following log was generate from: `git log 994e3aafe2a3d8d24c472bf21dcb15627e429fc2...upstream/master --reverse`:

----

## Added "id" package with "Slice" and "Map" of UUIDs (https://github.com/fabric8-services/fabric8-wit/issues/1856)

The `id` package defines these handy containers for UUIDs:

```go
type Slice []uuid.UUID
type Map map[uuid.UUID]struct{}
```

In recent tests that I discovered that I wrote a lot of duplicate code for dealing with UUIDs. That's where `Slice` and `Map` come in.

`Map` comes with these functions:

```go
func MapFromSlice(s Slice) Map
func (m Map) ToSlice() Slice
func (m Map) Copy() Map
func (m Map) ToString(sep string, fn ...func(ID uuid.UUID) string) string
func (m Map) String() string
```

Slice comes with these functions:

```go
func (s Slice) Diff(b Slice) Slice
func (s Slice) Sub(b Slice) Slice
func (s Slice) Unique(b Slice) Slice
func (s Slice) ToString(sep string, fn ...func(ID uuid.UUID) string) string
func (s Slice) String() string
```

----

## APIs for saving custom queries (https://github.com/fabric8-services/fabric8-wit/issues/1824)

APIs to create/show/delete a custom-query object.

----

## Ensure /apps endpoints return [] for empty arrays, not 'NULL' (https://github.com/fabric8-services/fabric8-wit/issues/1850)

* Ensure /apps endpoints return [] for empty arrays, not 'NULL'

fixes openshiftio/openshift.io#1924

----

## Fix search to included correct ancestors and rels to parent (https://github.com/fabric8-services/fabric8-wit/issues/1857)

* Support golden files for search response by sorting `"data"` and `"included"` arrays.
* Implemented sort.Interface in id.Slice
* Support AncestorLevel when calling GetAncestors
* Simplify string of ID creation
* Remove GetParentID function as it is superseded by GetAncestors
* Remove GetParentID function as it is superseded by GetAncestors
* Double check that the included work items only contains what's really needed.
* Ensure all but the root work items have a `parent` relationship.
* When not setting the `tree-view` query option to `true` no parent is included any longer (as discussed with Nimisha, MK, Sudipta, and Sahil)
* The `AncestorList` contained a function that was operating wrongly (`GetAncestorOf`). We didn't needed it so I removed.
* Fixed the `AncestorList.GetParentOf` function to also return correct parents when a given work item is not a leaf.
* `GetAncestors` can now query ancestors up to a certain level (parent, grandparent, great-grandparent, etc.)

Plenty of tests included.

### Example

1. Suppose you have this tree topology `A->B->C->D`.
2. Search for work items `C` and `D`.

Then you want these results

1. The `data` section in the JSONAPI shall contain work items `C` and `D`.
2. The `included` section in the JSONAPI shall contain `A` and `B`.
* Before this PR, `C` was also listed in the `included` array because it is an ancestor of `D`. But since it is part of the search results, it is not meant to be listed in the `included` array.
3. Work items `B`, `C`, and `D` have a parent relationship to point to their parent work item.

### Benefits

* We only return every work item once and not multiple times in different locations.
* We don't returns parents when the client didn't ask for them.
* We fetch parents for N matching work items using a single call to the database instead of N calls as done before.

----

## Fix sorting of WorkItemInterfaceSlice https://github.com/fabric8-services/fabric8-wit/pull/1861

Before I treated the `interface{}` object in the `"included"` response of the search `show` action as `*app.WorkItem` __pointers__. But it turned out that they are indeed just `app.WorkItem` __objects__. That is why my `WorkItemInterfaceSlice.Less` implementation was wrong. It can now handle pointers as well as values the same.