### PR TITLE
Bump core to b08df835c6019

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: b326eb11eb8e7b449369f07b839476ccbd754872
+- hash: b08df835c6019c8886fdd26c7bfc0867679b4470
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
update WIT(G) icons (https://github.com/fabric8-services/fabric8-wit/pull/1863)

Update icon for group type and work item types as per the below VD
https://redhat.invisionapp.com/share/NVEWGDU4W#/screens/269980285/

* fix(grouptype-icon): update icon for group types
* fix(type-icons): fix icon for wi type scenario and experience
* Update golden files
