### PR TITLE
Update `auth` to `f1fdb6`

### DIFF
--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 9f46f80981102c5e467aa94e007869e851ef7777
+- hash: f1fdb6ba4afb59a480bffcebce7dfd65344815e2
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/


### PR DESCRIPTION
This will deploy a script that set all remaining `feature_level` value from `nopreproduction` to `released` in the `users` table (plus a commit that fixes a couple of tests): https://github.com/fabric8-services/fabric8-auth/commit/fe45e5fa2a536bfdc9c61148ac2a67bdb4d4ecc3