### PR TITLE
[DO NOT MERGE] - Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -9,6 +9,8 @@ services:
     skip: True
     parameters:
       ws.k8s.api.server: f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com
+      k8s.api.server.base.path: /_p/oso
   - name: staging
     parameters:
       ws.k8s.api.server: f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com
+      k8s.api.server.base.path: ''

--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -7,23 +7,9 @@ services:
   environments:
   - name: production
     parameters:
-      k8s.api.server.base.path: /_p/oso
-      k8s.api.server.protocol: https
-      oauth.authorize.uri: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443/oauth/authorize
-      oauth.client.id: fabric8
-      oauth.issuer: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com.com:443
-      oauth.logout.uri: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443/connect/endsession?id_token={{id_token}}
-      openshift.console.url: https://console.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com/console/
       proxy.pass.url: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
       ws.k8s.api.server: api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
   - name: staging
     parameters:
-      k8s.api.server.base.path: /_p/oso
-      k8s.api.server.protocol: https
-      oauth.authorize.uri: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443/oauth/authorize
-      oauth.client.id: fabric8
-      oauth.issuer: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com.com:443
-      oauth.logout.uri: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443/connect/endsession?id_token={{id_token}}
-      openshift.console.url: https://console.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com/console/
       proxy.pass.url: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443
       ws.k8s.api.server: api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443

--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -7,9 +7,7 @@ services:
   environments:
   - name: production
     parameters:
-      proxy.pass.url: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
-      ws.k8s.api.server: api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
+      ws.k8s.api.server: f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
   - name: staging
     parameters:
-      proxy.pass.url: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443
-      ws.k8s.api.server: api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443
+      ws.k8s.api.server: f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443

--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -7,7 +7,23 @@ services:
   environments:
   - name: production
     parameters:
-      k8s.api.server: https://f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com
+      k8s.api.server.base.path: /_p/oso
+      k8s.api.server.protocol: https
+      oauth.authorize.uri: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443/oauth/authorize
+      oauth.client.id: fabric8
+      oauth.issuer: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com.com:443
+      oauth.logout.uri: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443/connect/endsession?id_token={{id_token}}
+      openshift.console.url: https://console.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com/console/
+      proxy.pass.url: https://api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
+      ws.k8s.api.server: api.f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
   - name: staging
     parameters:
-      k8s.api.server: https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com
+      k8s.api.server.base.path: /_p/oso
+      k8s.api.server.protocol: https
+      oauth.authorize.uri: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443/oauth/authorize
+      oauth.client.id: fabric8
+      oauth.issuer: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com.com:443
+      oauth.logout.uri: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443/connect/endsession?id_token={{id_token}}
+      openshift.console.url: https://console.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com/console/
+      proxy.pass.url: https://api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443
+      ws.k8s.api.server: api.f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443

--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -11,6 +11,3 @@ services:
   - name: staging
     parameters:
       k8s.api.server: https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com
-  - name: prod-preview
-    parameters:
-      k8s.api.server: https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com

--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -6,8 +6,9 @@ services:
   hash_length: 6
   environments:
   - name: production
+    skip: True
     parameters:
-      ws.k8s.api.server: f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com:443
+      ws.k8s.api.server: f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com
   - name: staging
     parameters:
-      ws.k8s.api.server: f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443
+      ws.k8s.api.server: f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com

--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -4,3 +4,13 @@ services:
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/
   hash_length: 6
+  environments:
+  - name: production
+    parameters:
+      k8s.api.server: https://f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com
+  - name: staging
+    parameters:
+      k8s.api.server: https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com
+  - name: prod-preview
+    parameters:
+      k8s.api.server: https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com


### PR DESCRIPTION
add support for proxy URLs

Is this the right way to apply the proxy URLs to Prod and Prod-preview?
Do I need to add the other env var from https://console.dsaas.openshift.com/console/project/dsaas-production/browse/config-maps/f8ui ?