### PR TITLE
Core latest 5297136

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2b9518b77ba031f00288f90b1a424de1c235fb08
+- hash: 5297136c02787f3d06c20dafe8d110b8196e993a
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
* Increase max length of name to 63
* Add separate attribute with workspace status
* Returns workitem children list according to order of execution
* fill "hasChildren" meta section in "children" relation of search response
* List ancestor IDs in search results 
* include siblings of matches in search results 

Fixes openshiftio/openshift.io#1869
Fixes openshiftio/openshift.io#2044
Related to openshiftio/openshift.io#1439