### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 023041e3bc44ef98c1a202f710f95ef587d70cc4
+- hash: b69a7e924090858387a60450690810b9e0def998
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* cd692350 fix(update): fix user profile requiring a browser refresh to show changes
* b69a7e92 fix(typo): updating the word `recommendations` to `insights`
* 69f19a38 fix(version): update ngx-widgets to 2.3.4
* dff3188f fix(version): update fabric8-planner to 0.42.25
* 1f1cdd08 feat(deployments): add time and color indicators to deployments chart tooltips
* 29936fd3 fix(deployments): use preventDefault instead of stopPropagation to handle clicking of items on deployment cards
* 7fb878ce fix(version): update fabric8-planner to 0.42.21
* c5601716 fix(build): remove unused gulp references
* a4f21110 chore(design): add UI arch designs to the repo for use in the wiki