### PR TITLE
Update tenant to version with GH auth

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 3bd3ec66ba150b949a31500d899a23d4c5973c4a
+- hash: 4e60a62f483794f6195904b9f11a94682ad6f090
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
This version includes support for GH authentication instead of relying on a whitelist of users configured at the admin-proxy level.