### PR TITLE
Update toggles to support GH auth/authz

### DIFF
--- a/dsaas-services/f8-toggles.yaml
+++ b/dsaas-services/f8-toggles.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 3085157369c1ddac9bafc492e1170bd92f5a6fda
+- hash: 4e60a62f483794f6195904b9f11a94682ad6f090
   name: fabric8-toggles
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-toggles/

--- a/dsaas-services/f8-toggles.yaml
+++ b/dsaas-services/f8-toggles.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 4e60a62f483794f6195904b9f11a94682ad6f090
+- hash: 02e36c34b9f60e26f203cc6d75c38592a90201ef
   name: fabric8-toggles
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-toggles/


### PR DESCRIPTION
This version includes support for GH authentication instead of relying on a whitelist of users configured at the admin-proxy level.