### PR TITLE
Bump core to 2901360

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 288c2567b20bfbe84cce7db056f24fc53dc4c46f
+- hash: 29013604d964060dafbf4995cafdfa9307d0c7f5
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# Replace $WITGROUP with typegroup.name (https://github.com/fabric8-services/fabric8-wit/issues/1929)
    
`typegroup.name` instead of `$WITGROUP` will be the new field to query for typegroups and the special handling for wit groups in the `search_repository.go` will go away soon. But in order to give the UI a chance to replace `$WITGROUP` with `typegroup.name` I wanted to get this change in as early as possible.

# Revert "Replace $WITGROUP with typegroup.name (https://github.com/fabric8-services/fabric8-wit/issues/1929)" (https://github.com/fabric8-services/fabric8-wit/issues/1930)
    
This reverts commit https://github.com/fabric8-services/fabric8-wit/commit/cebdda68f2d88e507fdf57533879c2f910fe693e.

# Add deployment quota information to deployments API (https://github.com/fabric8-services/fabric8-wit/issues/1922)

# fix(search): support old "$WITGROUP" as well as new "typegroup.name" fields (https://github.com/fabric8-services/fabric8-wit/issues/1932)
    
This addresses the backward compatibility problems I introduced with https://github.com/fabric8-services/fabric8-wit/issues/1929 (was reverted meanwhile).

`typegroup.name` instead of `$WITGROUP` will be the new field to query for typegroups and the special handling for wit groups in the `search_repository.go` will go away soon.

In fabric8-services/fabric8-wit#1929 I removed support for `$WITGROUP` but here I kept it and only added support for an additional `typegroup.name`. I've modified all tests that deal with `$WITGROUP` to now test for `typegroup.name` as well.