### PR TITLE
Add the Che tenant migration / maintenance service to dsaas

### DIFF
--- a/dsaas-services/che-tenant-maintainer.yaml
+++ b/dsaas-services/che-tenant-maintainer.yaml
@@ -1,8 +1,8 @@
 services:
 - hash:
   hash_length: 7
-  name: tenant-che-maintenance
+  name: che-tenant-maintainer
   parameters:
     IMAGE: registry.devshift.net/fabric8-services/fabric8-tenant-che-migration
-  path: /openshift/fabric8-tenant-che-maintenance.app.yml
+  path: /openshift/che-tenant-maintainer.app.yml
   url: https://github.com/fabric8-services/fabric8-tenant-che-migration

--- a/dsaas-services/tenant-che-maintenance.yaml
+++ b/dsaas-services/tenant-che-maintenance.yaml
@@ -1,0 +1,8 @@
+services:
+- hash:
+  hash_length: 7
+  name: tenant-che-maintenance
+  parameters:
+    IMAGE: registry.devshift.net/fabric8-services/fabric8-tenant-che-migration
+  path: /openshift/fabric8-tenant-che-maintenance.app.yml
+  url: https://github.com/fabric8-services/fabric8-tenant-che-migration


### PR DESCRIPTION
The tool used for Che tenant migration (and possibly other maintenance actions in the future), wrapped in a REST application, will now be added as a dsaas service.

This PR adds its yaml definition in the dsaas services.