### PR TITLE
Update after the rename of a repo

### DIFF
--- a/dsaas-services/che-tenant-maintainer.yaml
+++ b/dsaas-services/che-tenant-maintainer.yaml
@@ -5,4 +5,4 @@ services:
   parameters:
     IMAGE: registry.devshift.net/fabric8-services/fabric8-tenant-che-migration
   path: /openshift/che-tenant-maintainer.app.yml
-  url: https://github.com/fabric8-services/fabric8-tenant-che-migration
+  url: https://github.com/fabric8-services/che-tenant-maintainer


### PR DESCRIPTION
Update after the rename of the fabric8-tenant-che-migration repo to che-tenant-maintainer