### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1dab8d9cff7fdeb6339b894961846b0a4b2bee28
+- hash: 3d5c40fa68c7853713e8d63dc85aff770b79939a
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 3d5c40fa fix(deployments): Connect delete service to deployments frontend
* af700173 fix(deployments): Replace mock delete method with real request
* 101990e5 fix(codebases): updating message for workspace migration
* eb4f9961 fix(cleanup): fix errors being logged by the cleanup component unit tests
* 513712e4 (aptmac/master) fix(webpack): Update image bundler accuracy (#2633)
* 93a099dd fix(test): adds spec for gitAuthorize screen, summary screen, mission-runtime, pipeline
* b2d7a1d7 feat(service): changes the mock data to accomodate the actual service changes the mock data to accomodate the actual git services changes service to handle gitHub org along with gitHub Owner for git/launch api