### PR TITLE
Update auth to ac7591d

### DIFF
--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ac7591dc65abe9ac6d20dc6e7b4c611824647c93
+- hash: 198fad4388f3dc83938aed18b46a3f4d34d0e467
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/

--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0dd9dae7ea819f950d1a64b8a2241131a29f4028
+- hash: ac7591dc65abe9ac6d20dc6e7b4c611824647c93
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/


### PR DESCRIPTION
Include a fix to set the `featureLevel` to `released` by default for new users, and fix existing users in the DB.