### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: b838ad1c27e4f2bb1b1f1e651b3ab2d3f79aec47
+- hash: a4f2d0565e9fe05da45932022f7f914330f193d5
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* a4f2d056 clean-up(new-dashboard): remove unused observable causing x2 http calls (#2672)
* 5d5c2fd1 fix(my-spaces): create space wizard should not open when github is disconnected (#2657)
* 51bde866 fix(Analyze): Update the Space Dashboard to match new UX (#2662)
* c8dd239c fix(cleanup): fixed typo on cleanup page (it's -> its)
* eb7a2289 fix(deployments): fix display of environment labels
* 97f7de4b fix(patternfly-ng): taking advantage of modules so we import only what’s needed (#2650)
* 4fb440bb fix(launcher): handles get gitHub repos for import flow (#2658)
* 9ecb3cdc refactor(deployments): cleanup: removed unused imports (#2663)
* 008044cd fix(login): redirect to profile page after successful login (#2661)
* f7220806 add images for wiki documentation (#2668)