### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 9ecb3cdcc12792c30a241b869b5f641650f3b0bb
+- hash: 6b90fecbc0ff55d4696fe31c05708e1d304b85c9
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 6b90fecb fix(launcher): adds checks for data and bumps ngx-forge version to 0.0.64-development (#2678)
* 15360a86 fix(version): update fabric8-planner to 0.43.5 (#2677)
* b87a0dbc fix(version): updated ngx-forge to 0.0.63-development (#2675)
* a4f2d056 clean-up(new-dashboard): remove unused observable causing x2 http calls (#2672)
* 5d5c2fd1 fix(my-spaces): create space wizard should not open when github is disconnected (#2657)
* 51bde866 fix(Analyze): Update the Space Dashboard to match new UX (#2662)
* c8dd239c fix(cleanup): fixed typo on cleanup page (it's -> its)
* eb7a2289 fix(deployments): fix display of environment labels
* 97f7de4b fix(patternfly-ng): taking advantage of modules so we import only what’s needed (#2650)
* 4fb440bb fix(launcher): handles get gitHub repos for import flow (#2658)