### PR TITLE
Deploy core `2301c3`

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 767d2ce464c460f86e29ffaf591875328301a036
+- hash: 2301c3a2d7e42cfeaec21f57ef096e81b40408cc
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
Include calls to `rows.Close()` to attempt to fix the go routine leak reported in https://github.com/openshiftio/openshift.io/issues/2478