### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 087646e5e92dbe19e0495086d9ee582fa07267ef
+- hash: 487c4a0c298e2ffbede7ebd522b85272d8681db4
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 487c4a0c fix(cache): update webpack file name hashing strategy (#2703)
* eefa3ddf fix(launcher): removes isPageRedirect method as not needed (#2701)
* 6d3deda9 fix(space): space templates are managed from backend (#2664)