### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: fca17ac2962d3d14edc70fb3b748c3797de8d5df
+- hash: dccd11e478c43ee4b32305a33b2c4557fde8da5d
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* dccd11e4 fix(launcher): updates ngx-forge to 0.0.75-development (#2733)
* 40cca477 doc(feature-flag); add images for wiki page (#2734)
* 32a5087c fix(flow-selector): prevent null space value from crashing page (#2730)