### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 7a097a5b9fb14083008e39d610b01c0a07ebf978
+- hash: 5610921e2b1e363e90b258e92ae70890b8238338
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 5610921e fix(recent-workspaces-widget): remove TypeError warning from unit test (#2739)
* ac1139b2 fix(codebases): enable backaction outlet in routing (#2738)
* b3be26e1 fix(feature-flag): better check for empty featureflag icon (#2736)
* 944420da fix(home-dashboard): added workspaces widget to new home dashboard layout (#2720)
* 313346b1 fix(deployments): Refactor DeploymentsService to use DeploymentApiService (#2719)