### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: f43998eb0ed0e6d38b71afc8871a15373e495bed
+- hash: 7d2d3a418d9adc4cbe5062780e9c742228e1d462
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
- fix master build (#2768) (commit: 7d2d3a4) 
- feat(feature-flag): remove restricttedattribute for f8-feature-toggle (commit: 10551b0)
- fix(launcher): updates key names for launch and import call (#2758) (commit: c1f3a8d)
- Refactor EnvironmentWidget to remove DeploymentsService dependency (commit: 9d5fc87)
- fix(deployments): show reasonable graph label defaults (commit: 262d7f2) 
- fix(deployments): fix code style (commit: e2fb187) 
- refactor(deployments): move interfaces out of deployments.service.ts (commit: 3683fb7)
- refactor(deployments): add ScaledStat interface (commit: 13128a4)
- fix(routing): consistently redirect user to _error (commit: 1a1ad84)
- test(routing): test 404/_error behaviour and URL preservation (commit: 23024be)
- fix(routing): do not display notification on _error redirect (commit: 14dcf72)
- fix(version): update fabric8-planner to 0.43.23 (commit: 1b0d05d)