### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: f43998eb0ed0e6d38b71afc8871a15373e495bed
+- hash: 97dc68d14299dae4cd4eedcf2a374b177f6eb433
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 97dc68d1 fix(readme): adds a mechanism to handle multi-level NPM dependencies during NPM link (development) (#2752)
* 2c0f04b7 fix(login-service): remove unused imports
* 057b640e fix(environment-widget): add tooltip when deployment has no pods
* e5c25a84 fix(environment-widget): disable links when deployment has 0 pods
* 7d2d3a41 fix master build (#2768)
* 10551b02 feat(feature-flag): remove restricttedattribute for f8-feature-toggle component (#2763)
* c1f3a8df fix(launcher): updates key names for launch and import call (#2758)
* 9d5fc876 Refactor EnvironmentWidget to remove DeploymentsService dependency (#2755)
* e2fb187b fix(deployments): fix code style
* 262d7f24 fix(deployments): show reasonable graph label defaults
* 13128a47 refactor(deployments): add ScaledStat interface
* 3683fb70 refactor(deployments): move interfaces out of deployments.service.ts
* 14dcf722 fix(routing): do not display notification on _error redirect
* 23024beb test(routing): test 404/_error behaviour and URL preservation
* 1a1ad849 fix(routing): consistently redirect user to _error
* 1b0d05da fix(version): update fabric8-planner to 0.43.23