### PR TITLE
Update Core a55033

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ad9bb4634354eb8cb408bc9d7ea045300ef18890
+- hash: a5503361b7dc2f048d6fd3d0b2891dd996e86561
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
```
commit a5503361b7dc2f048d6fd3d0b2891dd996e86561
Author: Ibrahim Jarif <jarifibrahim@gmail.com>

    Add IST timezone to replaceTimes method in golden_files_test.go (#2038)

commit 429913ab921eca4209c11582f236013673d5ebfd
Author: Dipak Pawar <dipakpawar231@gmail.com>

    docs: update go dependency tool from glide to dep (#2042)

commit ac2f7333343955343fc858e630416c65c624b9f5
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Temporarily disable golint (#2040)

commit 86ec0f4cb028222aecd64af77fa3f8bd2c2c8a80
Author: Simon Tooke <stooke@redhat.com>

    Add multicluster support to /deployments API (#1883)

commit bf3f8b101277a46ad42d7cd255c0907f6868a229
Author: Baiju Muthukadan <baiju.m.mail@gmail.com>

    Snapshot docker image per PR push (#2020)

commit 39790bc7af4538ea0b75dd91a2a64e8f00c18808
Author: Dhriti Shikhar <dhriti.shikhar.rokz@gmail.com>

    Fixes typo (#2036)

commit e04bc845c777315f269df34aba6ef757f22da646
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Fixup for DB migration (#2035)

commit 6d258abe8c6fa8c805067f4f0d244e768ae7d820
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Fix db migration space templates (#2033)

commit 5e5caa3d2904252c9b0b47aaafa404601599b5c7
Author: Konrad Kleine <kwk@users.noreply.github.com>

    WIP: Space templates (#1148)

commit b82eea6b064ca354132697cc318c40c2bf14868a
Author: Xavier Coulon <xcoulon@redhat.com>

    Don't use IDs as part of log message Keys (#1971)

commit fc5a037f7fe7fee76fe1c9ed971ff8807d58b54e
Author: Alexey Kazakov <alkazako@redhat.com>

    Fix space creation (#2027)

commit f704d8cbd38e1ef04e923a0127cc176f96e165c6
Author: Shoubhik Bose <sbose78@gmail.com>

    return response from auth service 'as is' for space operations (#2026)

commit 1dd3aa8b0572539f08276ccaa75017f7b6a82846
Author: Xavier Coulon <xcoulon@redhat.com>

    Remove build dependency on `hg`/`mercurial` (#2023) (#2025)

commit 27f294676c816bb9c187f118c5bca24695562297
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Fix TestSuiteWorkItemLinkTypes/TestList/not_modified_using_IfNoneMatch_header (#2021)

commit f4d95471453d589aef2174d01b8cf8c5e5a0c65e
Author: Xavier Coulon <xcoulon@redhat.com>

    `make dev` fails after `dep` migration (#2018)

commit 5ee66f7db1f725c2a9399f2da9abe54a0e0e566d
Author: Konrad Kleine <kwk@users.noreply.github.com>

    test update fields of different kinds (#2017)

commit 6be02b6bcabc8dbbb684b0aeaf0408db8396cfdd
Author: Baiju Muthukadan <baiju.m.mail@gmail.com>

    Empty title should respond with client error (400)

commit 36b56bb765fc462c728dd505de1f3855e3fac4ff
Author: Konrad Kleine <kwk@users.noreply.github.com>

    improve replacement for times in golden files (#2012)

commit fe487bf9893cb03011cdc584efb52ad7778335f9
Author: Xavier Coulon <xcoulon@redhat.com>

    Migrate to `dep` for dependency management (OSIO#2873) (#2011)

commit 147c3fba4208489e4e87f3eb4265940bd4ef3c13
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Generate String() for app.JSONAPIErrors (#2015)

commit 03d87b4ba151363a273ff5c064ae8d1caf6acd89
Author: Elliott Baron <ebaron@redhat.com>

    Convert Kubernetes tests to use go-vcr (#2003)

commit abff831459c35d5a36e44a701ae19e0695ef8288
Author: Baiju Muthukadan <baiju.m.mail@gmail.com>

    Fix #1995 - WI full-text search returns system.number as null (#2009)

commit e53bc50446935461821a36e9a603d17fb67277c2
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Create test work items based off of planner item types (#2008)
```