### PR TITLE
Update `core` to a26ec5

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: a5503361b7dc2f048d6fd3d0b2891dd996e86561
+- hash: a26ec5ac552b28f9d29b70867fe73e03f8752d83
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
Include fix for OSIO#2865 reported in Sentry