### PR TITLE
RHEL based keycloak-deployment in staging

### DIFF
--- a/keycloak-services/keycloak.yaml
+++ b/keycloak-services/keycloak.yaml
@@ -9,10 +9,12 @@ services:
     parameters:
       REPLICAS: 3
       OPERATING_MODE: clustered
+      IMAGE: registry.devshift.net/fabric8-services/keycloak-postgres
   - name: staging
     parameters:
       REPLICAS: 3
       OPERATING_MODE: clustered
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/keycloak-postgres
   - name: appsec
     parameters:
       REPLICAS: 3


### PR DESCRIPTION
As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
to staging.

The build for RHEL is enabled in cico:
https://github.com/openshiftio/openshiftio-cico-jobs/blob/d9afbdbdc5bd0bfcfcd763530300671aeffedef3/devtools-ci-index.yaml#L2249

And in the feature repo itself:
https://github.com/fabric8-services/keycloak-deployment/pull/60

In this commit we are keeping the prod environment on CentOS but
shifting
the staging environment to RHEL in order to validate.