### PR TITLE
RHEL based f8-docs in staging

### DIFF
--- a/dsaas-services/f8-docs.yaml
+++ b/dsaas-services/f8-docs.yaml
@@ -4,3 +4,10 @@ services:
   path: /openshift/fabric8-online-docs.app.yaml
   url: https://github.com/fabric8io/fabric8-online-docs
   hash_length: 7
+  environments:
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8io/fabric8-online-docs
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8io/fabric8-online-docs


### PR DESCRIPTION
As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
to staging.

In this commit we are keeping the prod environment on CentOS but
shifting
the staging environment to RHEL in order to validate.