### PR TITLE
Update core

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 485a1631f2c9bf4c3b15b524ff2acb1499b738b4
+- hash: f47f4f929193bb8da8b1e169622678860c4f91c8
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
## Add PBI and bug to scrum execution typegroup (https://github.com/fabric8-services/fabric8-wit/pull/2056)
    
Add PBIs and Bugs to Execution type group in Scrum
    
This will allow you to go to an iteration and see PBIs, Bugs and Tasks.
    
This change is made because we didn't comply to [this slide](https://docs.google.com/presentation/d/18xKQmkf3UKlGoP7qLqUnrIYiflza674n_paUZXKuepA/edit#slide=id.g3758dca8f8_0_53) before:
    
![bildschirmfoto von 2018-04-25 16-50-11](https://user-images.githubusercontent.com/193408/39253732-cb3e1254-48a8-11e8-9bb8-d1aa1f98540e.png)
    
* Add golden files for work item type groups of generated, scrum, legacy (aka SDD) and base template
* Stabilize tests by using fixed WITG IDs and removing a non-used function.