### PR TITLE
Adds IMAGE param for fabric8-ui

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -10,8 +10,10 @@ services:
       ws_k8s_api_server: f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com
       k8s_api_server_base_path: '/'
       fabric8_feature_toggles_api_url: https://api.openshift.io/api/
+      IMAGE: registry.devshift.net/fabric8-ui/fabric8-ui
   - name: staging
     parameters:
       ws_k8s_api_server: f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com
       k8s_api_server_base_path: '/'
       fabric8_feature_toggles_api_url: https://api.prod-preview.openshift.io/api/
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-ui/fabric8-ui


### PR DESCRIPTION
This PR is part of an effort to migrate the services running in OSIO from CentOS
to RHEL.

This commit adds IMAGE as an environment parameter. At this stage it's not
currently being used by the service's openshift template, so this commit does
not affect staging or prod environments in any way.

However this enables the possibility of defining different urls for the image in
staging and prod, as soon as the service's openshift template is updated.