### PR TITLE
Adds IMAGE param for www.openshift.io

### DIFF
--- a/dsaas-services/www.openshift.io.yaml
+++ b/dsaas-services/www.openshift.io.yaml
@@ -4,3 +4,10 @@ services:
   path: /openshift/www.openshift.io.app.yaml
   url: https://github.com/openshiftio/openshift.io
   hash_length: 6
+  environments:
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8io/wwwopenshiftio
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8io/wwwopenshiftio


### PR DESCRIPTION
This PR is part of an effort to migrate the services running in OSIO from
CentOS to RHEL.

This commit adds IMAGE as an environment parameter. At this stage it's not
currently being used by the service's openshift template, so this commit does
not affect staging or prod environments in any way.

However this enables the possibility of defining different urls for the image
in staging and prod, as soon as the service's openshift template is updated.