### PR TITLE
Adds IMAGE param for fabric8-toggles and service

### DIFF
--- a/dsaas-services/f8-toggles-service.yaml
+++ b/dsaas-services/f8-toggles-service.yaml
@@ -4,3 +4,11 @@ services:
   path: /openshift/app.yml
   url: https://github.com/fabric8-services/fabric8-toggles-service/
   hash_length: 6
+  environments:
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-toggles-service
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8-services/fabric8-toggles-service
+

--- a/dsaas-services/f8-toggles.yaml
+++ b/dsaas-services/f8-toggles.yaml
@@ -3,3 +3,10 @@ services:
   name: fabric8-toggles
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-toggles/
+  environments:
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-toggles
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8-services/fabric8-toggles


### PR DESCRIPTION
This PR is part of an effort to migrate the services running in OSIO from CentOS
to RHEL.

This commit adds IMAGE as an environment parameter. At this stage it's not
currently being used by the service's openshift template, so this commit does
not affect staging or prod environments in any way.

However this enables the possibility of defining different urls for the image in
staging and prod, as soon as the service's openshift template is updated.