### PR TITLE
Adds IMAGE param for zabbix-status-api

### DIFF
--- a/dsaas-services/status-api.yaml
+++ b/dsaas-services/status-api.yaml
@@ -4,3 +4,10 @@ services:
   path: /openshift/status-api.app.yaml
   url: https://github.com/openshiftio/status-api/
   hash_length: 7
+  environments:
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/openshiftio/zabbix-status-api
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/openshiftio/zabbix-status-api


### PR DESCRIPTION
This PR is part of an effort to migrate the services running in OSIO from CentOS
to RHEL.

This commit adds IMAGE as an environment parameter. At this stage it's not
currently being used by the service's openshift template, so this commit does
not affect staging or prod environments in any way.

However this enables the possibility of defining different urls for the image in
staging and prod, as soon as the service's openshift template is updated.