### PR TITLE
Adds IMAGE param for fabric8-wit

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -8,6 +8,8 @@ services:
   - name: staging
     parameters:
       REPLICAS: 2
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-wit
   - name: production
     parameters:
       REPLICAS: 4
+      IMAGE: registry.devshift.net/fabric8-services/fabric8-wit


### PR DESCRIPTION
This PR is part of an effort to migrate the services running in OSIO from CentOS
to RHEL.

This commit adds IMAGE as an environment parameter. At this stage it's not
currently being used by the service's openshift template, so this commit does
not affect staging or prod environments in any way.

However this enables the possibility of defining different urls for the image in
staging and prod, as soon as the service's openshift template is updated.