### PR TITLE
Adds IMAGE parameters to several f8 services

### DIFF
--- a/dsaas-services/f8-admin-proxy.yaml
+++ b/dsaas-services/f8-admin-proxy.yaml
@@ -3,3 +3,10 @@ services:
   name: fabric8-admin-proxy
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-admin-proxy/
+  environments:
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8-services/fabric8-admin-proxy
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-admin-proxy

--- a/dsaas-services/f8-notification.yaml
+++ b/dsaas-services/f8-notification.yaml
@@ -4,3 +4,10 @@ services:
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-notification/
   hash_length: 6
+  environments:
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8-services/fabric8-notification
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-notification

--- a/dsaas-services/f8-oso-proxy.yaml
+++ b/dsaas-services/f8-oso-proxy.yaml
@@ -3,3 +3,10 @@ services:
   name: fabric8-oso-proxy
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-oso-proxy/
+  environments:
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8-services/fabric8-oso-proxy
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-oso-proxy

--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -4,3 +4,10 @@ services:
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/
   hash_length: 6
+  environments:
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8-services/fabric8-tenant
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-tenant


### PR DESCRIPTION
This PR is part of an effort to migrate the services running in OSIO
from CentOS to RHEL.

This commit adds IMAGE as an environment parameter. At this stage it's
not currently being used by the service's openshift template, so this
commit does not affect staging or prod environments in any way.

However this enables the possibility of defining different urls for the
image in staging and prod, as soon as the service's openshift template
is updated.