### PR TITLE
switch tenant-log-indirector service to RHEL

### DIFF
--- a/dsaas-services/tenant-log-indirector.yaml
+++ b/dsaas-services/tenant-log-indirector.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2adba70eda7d15753c0746b8e61f189d46787c3e
+- hash: ee1ae47ff66774c32fd7a77174c5fef3598fc2bc
   name: tenant-log-indirector
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/openshiftio/tenant-log-indirector


### PR DESCRIPTION
switch tenant-log-indirector service to RHEL
cc: @aslakknutsen @jmelis 