### PR TITLE
Update jenkins-idler

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: a189fbb4b5bc528b38896f13537f03b30a33a17d
+- hash: 4d808293b0e902aefb80ce7d2c030d99fb18319a
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
A few user changes :

* Idle long build even if they are active if they are active for a long time
  then idle them (setting: JC_IDLE_LONG_BUILD).
* Idle content-repository along jenkins when idling.
* Add promotheus monitoring