### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: eb562f125a079ca94c0d7d20a6d2fa03b5b1bab8
+- hash: d1233b2f4498c42f8b03ec4f260f24f299f3b8d7
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* d1233b2f fix(build): add gcc-c++ to build
* ba1c4015 fix(build): change google-chrome to use beta since stable is missing
* 0da88a01 Revert RHEL effort commits (#2820)
* 3280ad4b fix(build-master): remove failing sematic-build to unblock master build (#2819)
* 9a91d74d disable build from running func tests
* 22fa74f7 Fixes bug in second pass of build script (#2816)
* d513dddf feat(bootstrap): add bootstrap module and update OauthConfigStore (#2764)
* e7e4af98 (jiekang/master) Deploy on RHEL based container (#2805)
* d74f1461 fix(version): update fabric8-planner to 0.45.5 (#2807)
* cb87ba17 fix(version): update fabric8-planner to 0.45.4 (#2802)
* 06cb80fe fix(pipelines): refactor pipelines service and use it in pipelines widgets (#2792)
* d6970cbf fix(version): update ngx-fabric8-wit to 6.20.3 (#2803)
* 3e9dab8f fix(version): update fabric8-stack-analysis-ui to 0.12.1 (#2799)
* f2d8bb3e fix(collaborators): sort collaborators (#2793)
* a672290d fix(deployments): round CPU usage data points (#2786)