### PR TITLE
Deploy RHEL based keycloak into production

### DIFF
--- a/keycloak-services/keycloak.yaml
+++ b/keycloak-services/keycloak.yaml
@@ -9,7 +9,7 @@ services:
     parameters:
       REPLICAS: 3
       OPERATING_MODE: clustered
-      IMAGE: registry.devshift.net/fabric8-services/keycloak-postgres
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/keycloak-postgres
   - name: staging
     parameters:
       REPLICAS: 3


### PR DESCRIPTION
Please deploy the RHEL based keycloak into production after verifying that it works correctly in prod-preview