### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: a4e1e0bf091066045bb944eccf9480f4b6f9050e
+- hash: a9279445ff5eb4cf4ea3c0069ac6ea60a5b33db4
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 7639d386 Tweak Deployment card "Deletion" state behaviour (#2785)
* a9279445 Continue execution if semantic-release fails (#2832)
* cfa53963 fix(deployments): fix bug where Deployment card charts become corrupt (#2838)
* 3f3288af fix(version): update fabric8-planner to 0.45.6 (#2834)
* 9d371c96 Turn off semantic-release.
* 7137eb5e fix(infotip): fix text wrapping and alignment (#2831)
* 8d09cc86 fix(build): add package-lock again, first was blocked by 2nd ignore
* fa98d42a fix(build): remove gitignore for package-lock
* 14224b0c Reenable run_functional_tests in cico build script (#2830)
* eee60047 fix(build): add package-lock (#2829)
* a31f604f Reapply RHEL enablement (#2828)