### PR TITLE
Update Core to 0736f0

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1d64ec3a37d5e859c46effe864502774826245a8
+- hash: 0736f0d945e2c2ae356b351f8110c5e20da4cc3f
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
```
commit 0736f0d945e2c2ae356b351f8110c5e20da4cc3f
Author: Ilya Buziuk <ilyabuziuk@gmail.com>

    Adding support of 'clusterFull' property while obtaining Che server state (#2072)

commit a588fc9fd8a623a2ad846aa0620b0c2b4e2f6f35
Author: Suraj Deshmukh <surajd.service@gmail.com>

    Add capacity flag to namespaces - `cluster-capacity-exhausted` (#2074)

commit c216e1b66e039d7986ad8565d7c1ebffe97bb31c
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Call WI's conversion from model to to JSONAPI and back using the WI's type (#2069)

commit 1bda5e3601ffe2ed37207b5eac74c1bb36bd428f
Author: Elliott Baron <ebaron@redhat.com>

    Identify deployments using build metadata (#2065)

commit b42020a309299e270d425b550461442a908344bb
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Make test for listing WITs of predefined space templates aware of IDs (#2068)

commit 9489007f8fcc343abb40a6a673efa8de8c371722
Author: Konrad Kleine <kwk@users.noreply.github.com>

    Fix scrum icons (#2067)
```