### PR TITLE
remove CHE5 service from preview / prod

### DIFF
--- a/dsaas-services/rh-che.yaml
+++ b/dsaas-services/rh-che.yaml
@@ -1,8 +1,0 @@
-services:
-- hash: bb8dee7ccecd26485bf87551da409d3abbd19563
-  hash_length: 7
-  name: rh-che
-  parameters:
-    IMAGE: registry.devshift.net/che/che-multiuser
-  path: /openshift/rh-che.app.yaml
-  url: https://github.com/redhat-developer/rh-che


### PR DESCRIPTION
CHE5 is deprecated in favor of CHE6, currently CHE5 is not used on prod-preview / prod for a while so we can finally terminate it.

needed for:
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1577
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1239
