### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 29cea1c5976faffa7c0fee5ff56b215126cede0f
+- hash: 5591b6a45764a01d156278099b0464dae25e0baa
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 5591b6a4 fix(version): update fabric8-planner to 0.46.7 (#2881)
* 944292f4 fix(version): update fabric8-stack-analysis-ui to 0.12.5
* 00a2c2c4 fix(ux): removes stack report from applications in dashboard. Removes from modules and specs
* bbabce19 fix(version): update ngx-forge to 0.0.88
* 772c8b3b fix(case): make the application name to always be lowercase