### PR TITLE
Update fabric8-tenant-jenkins version to 4.0.76

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: f1e987f012ab12ce056fe1e38c10e0c65b136d64
+- hash: bdd3af3f9fd16c56729a29ec78d6671083ff6c4c
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
With this change we make sure that if there are any plugins to be deleted, they would be cleaned from JENKINS_HOME/plugins folder. After getting this to prod there will be no immediate effect on Jenkins servers, whenever any plugin is updated then it will check if it needs to delete any plugin.

https://github.com/openshiftio/openshift.io/issues/3466

cc: @aslakknutsen 