### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 6023aaebc027d982cb96a616903b1864601e32a9
+- hash: 9607a283971f2ae99c719942b8606ff528bbad8a
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 9607a283 fix(launcher): Disable continue button on load (#2938)
* ed556f86 fix(version): downgrade planner to 0.48.0 to fix error in 0.48.1 (#2937)
* 2c4a8919 fix(version): update fabric8-planner to 0.48.1 (#2932)
* 74d8fe16 fix(feature): retrieve all features via GetFeatureByStrategy enpoint (#2933)
* 8e28b549 fix(pipelines): provide info to user until stages starts, adds specs (#2921)
* f54bfc0a fix(version): update fabric8-planner to 0.47.1 (#2923)
* 056ef01c fix(deployments): reappearing deployments continue updates (#2910)
* de9d62f7 fix(dashboard): Hide widget buttons in foreign user space (#2898)
* 974bf5a6  fix(pipelines): Disabled adding to other user's space in pipelines component and set the recent-pipeline's build config (#2842)
* c0ecada4 fix(deployments): introduce empty-state screen for when there are no applications (#2917)
* b37506eb fix(launcher): Don't allow a user to enter the existing application name (#2902)
* f96ab12d fix(version): update ngx-widgets to 2.4.1 (#2922)
* 26f222dd feat(deployments): application row title can be clicked to toggle collapse
* b8316e06 feat(deployments): deployment rows expand upon click
* b61581ea fix(version): update fabric8-planner to 0.47.0 (#2920)
* e94dfc41 fix(lock): update the package-lock (#2918)
* ec70d103 fix(linting): fix pipelines component less indentation (#2916)
* 8d84c75f fix(launcher) : fixes launcher flow in pipelines view with feature flag (#2899)
* 08a12f81 fix(version): update fabric8-planner to 0.46.16 (#2913)