### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 9607a283971f2ae99c719942b8606ff528bbad8a
+- hash: f301d52a9b5441c129498550144ac223f83e7a75
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* f301d52a fix(launcher): removed flags to make the application create screen work
* 7fb3c24f fix(work-item-widget): ensure valid links are provided for planner work items (#2925)
* b895527b fix(home): update content of the banner (#2930)
* fc0b40a1 fix(deployments): move http error handling from deployments service to deployments api service (#2941)
* 3e54f0e0 fix(settings): do not allow deselection of feature levels (#2924)
* 686ef5eb Hide buttons from add-codebase-widget when in a foreign user space.  (#2931)
* c0a71a3c fix(spaces): do not refresh page on Enter (#2940)
* 2f11345f fix(my-spaces): enable new Space overlay (#2939)