### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: f301d52a9b5441c129498550144ac223f83e7a75
+- hash: 4d02ffafe27d53c5806abc5bc92a644053ef949b
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 4d02ffafe fix(version): update fabric8-planner to 0.49.4 (#2961)
* f9a086927 fix(version): update fabric8-planner to 0.49.2 (#2959)
* c88ae4fbc fix(add-app-overlay): rename contextService variable
* eff3fed3a fix(add-app-overlay): added unit tests for checking null space value
* 0cba2e82e fix(add-app-overlay): fix indentation of unit tests from 4 to 2 spaces
* 325fbb394 fix(add-app-overlay): fix null id error when creating app from non-space associated page
* 33a2a31b6 fix(version): update fabric8-planner to 0.49.1 (#2956)
* 8b989782f fix(version): update ngx-widgets to 2.4.2 (#2952)
* c63fd59a3 fix(version): update ngx-forge version to 0.2.9
* cb14ae168 fix(version): Update planner version to 0.48.1 (#2943)