### PR TITLE
Update Jenkins Idler

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1cc3a07495fde2abfa6bcca9fc1c8e9aa4974ab0
+- hash: e501e24a559a261eb48afd3aab48364dd3690a33
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
- Increase default number of replicas to 3
- Add more logging
- Add a new Status API.
- Increase max retry count from 3 to 10