### PR TITLE
Revert bogus previous update

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -11,7 +11,7 @@ services:
   - name: staging
     parameters:
       IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-jenkins-idler
-- hash: a6bcdf660e96c0599e7aea9e20037afe3eb9cc2c
+- hash: 1599ea8fdd583540fd4c300f9e4b1e37f7b5be41
   hash_length: 6
   name: fabric8-jenkins-proxy
   path: /openshift/jenkins-proxy.app.yaml

--- a/dsaas-services/f8-oso-proxy.yaml
+++ b/dsaas-services/f8-oso-proxy.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1599ea8fdd583540fd4c300f9e4b1e37f7b5be41
+- hash: 90e72b8a1590eee8cda0499116121224dbc34b69
   name: fabric8-oso-proxy
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-oso-proxy/


### PR DESCRIPTION
In 4f3a42ba7e4343a272def814759a12a7c3cc8466 I have updated the wrong file
f8-oso-proxy when I should have done it in f8-jenkins-idler, fixing it.