### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: cdcec5828015922c11f6643353c76102ccb62f6a
+- hash: 7494b283e1b86875aae6592b119ace9c86dd2d3c
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 7494b283e fix(launcher): fixes selection of runtime and mission step
* 8071ebfde chore: update to version 0.2.28
* c4ee24b97 chore: updated ngx-forge to 0.2.25
* 374d74e32 fix: changed to use new catalog endpoint
* afe2fe769 fix(add-codebase): remove the deprecated codebases-add module
* d54ab9f4c fix(add-codebase): replace instance of add-codebase slider with showAddAppOverlay
* 4da2f0c1d fix(launcher): remove feature-flag wrapper for launcher functionality
* 9ce841f00 fix(launcher): remove unused forge-wizard related functionality
* ba0a02aa5 fix(launcher): remove deprecated forge-wizard
* cffecbf09 fix(launcher): remove forge-config and relocate token-provider.service
* 8500fba5e fix(launcher): remove abstract-wizard and import-pages
* 20f4a3012 fix(launcher): remove the deprecated space-wizard
* 9df4796c0 fix(launcher): remove the old quickstart-wizard
* 48a6d06bf fix(launcher): remove the old import-wizard
* 1dff33bde fix(launcher): remove the flow-selector
* c3468b217 fix(launcher): remove usage of openForgeWizard function
* fb600101d fix(deployments): increase width of toolbar filter input (#2987)
* 800c3eeb5 fix(version): update fabric8-planner to 0.49.7 (#2996)
* d9bc8a9ac fix(ngrx): added entity library for data normalization (#2991)
* 25177f4c9 fix(webpack): resolve ngx-forge sourcemap warnings (#2950)