### PR TITLE
Revert jenkins-proxy hash to last successful build

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -11,7 +11,7 @@ services:
   - name: staging
     parameters:
       IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-jenkins-idler
-- hash: 1599ea8fdd583540fd4c300f9e4b1e37f7b5be41
+- hash: a6bcdf660e96c0599e7aea9e20037afe3eb9cc2c
   hash_length: 6
   name: fabric8-jenkins-proxy
   path: /openshift/jenkins-proxy.app.yaml


### PR DESCRIPTION
Current hash corresponds to a commit that didn't build successfully: https://ci.centos.org/view/Devtools/job/devtools-fabric8-jenkins-proxy-build-master/150/

Reverting to the hash from the last successful build here: https://ci.centos.org/view/Devtools/job/devtools-fabric8-jenkins-proxy-build-master/148/