### PR TITLE
f8-oso-proxy pulling from quay for staging

### DIFF
--- a/dsaas-services/f8-oso-proxy.yaml
+++ b/dsaas-services/f8-oso-proxy.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: cdf53026fdd22d49699e320d924a2b39bb232413
+- hash: ced19c8a120585e756b1da9c7686149aba7e665a
   name: fabric8-oso-proxy
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-oso-proxy/

--- a/dsaas-services/f8-oso-proxy.yaml
+++ b/dsaas-services/f8-oso-proxy.yaml
@@ -6,7 +6,7 @@ services:
   environments:
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-oso-proxy
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services/fabric8-oso-proxy
   - name: staging
     parameters:
-      IMAGE: quay.io/openshiftio/fabric8-services-fabric8-oso-proxy
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-oso-proxy

--- a/dsaas-services/f8-oso-proxy.yaml
+++ b/dsaas-services/f8-oso-proxy.yaml
@@ -9,4 +9,4 @@ services:
       IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-oso-proxy
   - name: staging
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-oso-proxy
+      IMAGE: quay.io/openshiftio/fabric8-services-fabric8-oso-proxy

--- a/dsaas-services/f8-oso-proxy.yaml
+++ b/dsaas-services/f8-oso-proxy.yaml
@@ -6,7 +6,7 @@ services:
   environments:
   - name: production
     parameters:
-      IMAGE: quay.io/openshiftio/rhel-fabric8-services/fabric8-oso-proxy
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-oso-proxy
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-oso-proxy


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.