### PR TITLE
f8-toggles-service pulling from quay for staging

### DIFF
--- a/dsaas-services/f8-toggles-service.yaml
+++ b/dsaas-services/f8-toggles-service.yaml
@@ -7,8 +7,7 @@ services:
   environments:
   - name: staging
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-toggles-service
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-toggles-service
   - name: production
     parameters:
       IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-toggles-service
-


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.