### PR TITLE
Update fabric8-tenant-jenkins version to 4.0.88

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0d421040973ab8a76e7a9ed54f2770b0aac96ab0
+- hash: afa18b85f642202308c6d1ed6f56f1da5144dcc5
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
cc @aslakknutsen 
It resolves - https://github.com/fabric8io/openshift-jenkins-s2i-config/issues/174 - This resolves the plugins dependency errors from the Jenkins pod logs
PR link https://github.com/fabric8io/openshift-jenkins-s2i-config/pull/173