### PR TITLE
Deploy f8-admin-proxy into prod from Quay

### DIFF
--- a/dsaas-services/f8-admin-proxy.yaml
+++ b/dsaas-services/f8-admin-proxy.yaml
@@ -1,12 +1,12 @@
 services:
-- hash: 8fd02627f1f94f961ef5ad9489a4a2b10e83db35
+- hash: 612c68db001754e8778f35080895cf1f1811ddf2
   name: fabric8-admin-proxy
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-admin-proxy/
   environments:
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-admin-proxy
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-admin-proxy
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-admin-proxy


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.