### PR TITLE
Deploy f8-notification into prod from Quay

### DIFF
--- a/dsaas-services/f8-notification.yaml
+++ b/dsaas-services/f8-notification.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 907d3253a9e8ae42f61ce7c931fd920df20ee0ec
+- hash: afc3754876d8d496892d6703ecd2c8c134267fef
   name: fabric8-notification
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-notification/
@@ -7,7 +7,7 @@ services:
   environments:
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-notification
+      IMAGE: quay.io/openshiftio/fabric8-services-fabric8-notification
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/fabric8-services-fabric8-notification


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.