### PR TITLE
Deploy toggles into prod from Quay

### DIFF
--- a/dsaas-services/f8-toggles.yaml
+++ b/dsaas-services/f8-toggles.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: f8fe00b75e3f2c5cbb7449115c88615ddd644606
+- hash: 2f7fdb46c3a923c3d7ce9e6c9e9e13a41df8fd1e
   name: fabric8-toggles
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-toggles/
@@ -9,4 +9,4 @@ services:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-toggles
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-toggles
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-toggles


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.