### PR TITLE
Deploy f8-toggles-service into prod from Quay

### DIFF
--- a/dsaas-services/f8-toggles-service.yaml
+++ b/dsaas-services/f8-toggles-service.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1f6adf2e6285a83cbe6943313f701672cd09c6da
+- hash: 67158d5d126d3ab7f4cfaeafd3b44aa9c01a454c
   name: fabric8-toggles-service
   path: /openshift/app.yml
   url: https://github.com/fabric8-services/fabric8-toggles-service/
@@ -10,4 +10,4 @@ services:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-toggles-service
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-toggles-service
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-toggles-service


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.