### PR TITLE
Deploy wwwopenshiftio into prod from Quay

### DIFF
--- a/dsaas-services/www.openshift.io.yaml
+++ b/dsaas-services/www.openshift.io.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ad935e8bf3b135c03b95a4d745242953a4be6f9c
+- hash: 139ec187a678c0d4300bfa733eb364837911c9a1
   name: openshift.io
   path: /openshift/www.openshift.io.app.yaml
   url: https://github.com/openshiftio/openshift.io
@@ -7,7 +7,7 @@ services:
   environments:
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8io/wwwopenshiftio
+      IMAGE: quay.io/openshiftio/rhel-fabric8io-wwwopenshiftio
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/rhel-fabric8io-wwwopenshiftio

--- a/dsaas-services/www.openshift.io.yaml
+++ b/dsaas-services/www.openshift.io.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 139ec187a678c0d4300bfa733eb364837911c9a1
+- hash: 4cd2a134b4728c868b340f91810fb143c077fb19
   name: openshift.io
   path: /openshift/www.openshift.io.app.yaml
   url: https://github.com/openshiftio/openshift.io


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.