### PR TITLE
Update f8-ui commit to pull from quay

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 74dbef5af476a51399cb4dd46c6abd1ae21e5e3c
+- hash: 32da7603845e483f4c32f522d9942d1cad087a14
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/
@@ -10,7 +10,7 @@ services:
       ws_k8s_api_server: f8osoproxy-test-dsaas-production.09b5.dsaas.openshiftapps.com
       k8s_api_server_base_path: '/'
       fabric8_feature_toggles_api_url: https://api.openshift.io/api/
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-ui/fabric8-ui
+      IMAGE: quay.io/openshiftio/rhel-fabric8-ui-fabric8-ui
   - name: staging
     parameters:
       ws_k8s_api_server: f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com


### PR DESCRIPTION
* 32da76038 fix(version): update fabric8-planner to 0.49.12
* c07d461d1 fix(header): correct gradient and underline in navbars (#3037)
* 8b817e90c fix(build): Move to Quay.io (#3033)
* dbd8e93ab fix(feature-flag): use filled-in squarish icon for feature-flag icon (#2944)
* fa456f6d4 fix(version): update fabric8-planner to 0.49.11 (#3032)
* 50ce4b01f fix(header): Change stylings for subheaders (#2984)
* 5379b7c1b fix(app-launcher): disallow starting number and spaces in application name (#3025)
* f5f9bd32e refactor(deployments): clean up DeploymentsService DI (#2983)
* b77de4cd2 style(deployments): DeleteDeploymentModal code style and tests (#2976)
* ea548e98e fix(analyze-overview): correctly hide create app button (#3007)
* c01a0d7d7 fix(http): short term cache for http GET requests (#3001)
* 628f91fc8 fix(package): upversion libs that use peer deps
* 51761ba13 fix(package-lock): update package-lock
* 734dee046 fix(webpack): add 'testing' alias for unit tests
* c725b767d fix(webpack): remove custom module resolution locations for test
* a30d30344 fix(webpack): remove custom path resolution for fabric8-analytics-dependency-editor
* 7fd3595d5 fix(dependencies): update ng2-restangular to ngx-restangular
* d685163ac fix(imports): use relative imports for modules in src/
* 9e6ce4e95 fix(tsconfig): define paths for angular and rxjs
* 158968a40 fix(webpack): remove custom module resolution locations
* c8f7a54e5 fix(webpack): turn off symlinks option in dev to allow `npm link`
* 57d12fa63 refactor(planner): remove deprecated module `WorkItemDetailAddTypeSelectorModule` from imports (#3010)
* 62f753f2b fix(launcher): allow to fail properly for continuous hyphens or underscores in the application name. (#3012)
* 1ba58d2f7 refactor(deployments): rename environment card resource status (#3013)
* 5101c810c fix(applications-widget): show in-progress message for newly created apps (#2975)