### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 8f493457c2c0b9b8cf7c8c0b6283c1d66466b0f1
+- hash: 713f61a9c130db4be544ea7a25644dca31dceed5
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 713f61a9c fix(version): update fabric8-planner to 0.50.3 (#3048)
* 40b92c7a8 fix(edit-space-description): prevent pointer cursor from appearing when hovering description of another user's space (#3050)
* 3479194f2 fix(assets): change absolute svg paths to relative (#3049)
* f618fde13 fix(patternfly-ng): remove deprecations related to module imports (#3043)