### PR TITLE
Reverts the f8ui image path back to quay

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -18,4 +18,4 @@ services:
       k8s_api_server_base_path: '/'
       fabric8_feature_toggles_api_url: https://api.prod-preview.openshift.io/api/
       fabric8_jenkins_api_url: https://jenkins.api.prod-preview.openshift.io
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-ui/fabric8-ui
+      IMAGE: quay.io/openshiftio/rhel-fabric8-ui-fabric8-ui


### PR DESCRIPTION
I believe it was accidentally changed in this commit:
https://github.com/openshiftio/saas-openshiftio/commit/928a2884bb63153babcad64031cf485bf0e072bf#diff-25ffa3356d445a9aaeba21b9993d5cf4R21