### PR TITLE
Updating rh-che to the latest version (build against upstream 6.7.1)

### DIFF
--- a/dsaas-services/rh-che6.yaml
+++ b/dsaas-services/rh-che6.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1b7a9e47facf14a3c9a31a2a130f48de8fc1bf55
+- hash: 5e0dd2441e88f532df6c9ba0023b7ce86ba22aea
   hash_length: 7
   name: rh-che6
   path: /openshift/rh-che.app.yaml

--- a/dsaas-services/rh-che6.yaml
+++ b/dsaas-services/rh-che6.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 5e0dd2441e88f532df6c9ba0023b7ce86ba22aea
+- hash: 7d88e4900d0452eec817bdb008368ae64c7a7b25
   hash_length: 7
   name: rh-che6
   path: /openshift/rh-che.app.yaml


### PR DESCRIPTION
6.7.1 version is including security fix for potential XSS attacks - https://github.com/eclipse/che/pull/10198