### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: cd53cbe6f4d8d1cef6803c8dfcd511f3ae910f45
+- hash: 051c96feeaa5d7be42339f7bf11b6711831f72fb
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
db: remove "resolution" field from "impediment" WIT (fabric8-services/fabric8-wit#2140)

Add migration step to remove enum field "resolution" in "impediment" WIT before re-adding it with the "agile" space template.
    
See also openshiftio/openshift.io#3879.