### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 051c96feeaa5d7be42339f7bf11b6711831f72fb
+- hash: e471357cb814641a43cfda7e6c52a901a2af6e00
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
Re-run modification of work item type in DB (fabric8-services/fabric8-wit#2141)
    
This effectively re-runs the following DB migrations only with different IDs for the work items, spaces and space templates.
    
  1. 094-changes-to-agile-template-test.sql
  2. 095-remove-resolution-field-from-impediment.sql
    
See openshiftio/openshift.io#3880 for an explanation why we need this
See openshiftio/openshift.io#3879 for the error and the followup errors