### PR TITLE
f8docs pulling from quay for staging

### DIFF
--- a/dsaas-services/f8-docs.yaml
+++ b/dsaas-services/f8-docs.yaml
@@ -10,4 +10,4 @@ services:
       IMAGE: prod.registry.devshift.net/osio-prod/fabric8io/fabric8-online-docs
   - name: staging
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8io/fabric8-online-docs
+      IMAGE: quay.io/openshiftio/rhel-fabric8io-fabric8-online-docs


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.