### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 258befb2f2ba01a1b20b0fee6e47fa47c7e778e6
+- hash: a848b211c1af302448c13b49a42da78a18cd29e7
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* a848b211c fix(version): updates ngx-forge to 0.5.3
* 0d36d1d07 fix(launcher): removed unused service
* 49f33f53d fix(planner-routing): consuming one PlannerModule and got the /board back (#3103)
* d21a2fc55 fix(profile): update feature-flag indicator should not sent feature-level information (#3098)
* 97b0fd119 fix(space-description-widget): fix masthead to display real user info… (#3073)
* ea83f1adf fix(collaborators): added default image if user avatar is not present. Also added username to collab page and selected items in dropdown. (#3082)
* 56e1b22e2 clean(package-lock): attempt to sort out CI/CD master build failing (#3094)
* 4c692dc92 fix(my-spaces): don't hide space list and fix create space button (#3093)
* ab4d61713 fix(build): fix build with external feature-flags lib (#3092)
* 0ea1df8f5 fix(feature-flag): remove git merge text left behind
* b31cdf4f3 (andrewazores/master) refactor(feature-flag): use ext library (#3078)
* d0dbfb700 fix(webpack): create smaller chunks (#3083)
* f10053812 refactor(deployments): Deployments component cleanup (#3079)
* b1b95da67 fix(recent-pipelines-widget): retrieve contextPath from ContextService.currentUser instead of Contexts.current (#3071)
* c28cb6054 fix(pipelines): removes trailing slash (#3076)
* ae2ef1cd0 fix(telemetry): Add telemetry for App Launcher (#3000)
* 4d837bc9f fix(deployments): remove filter for "test" environment (#3074)
* d24760171 fix(profile): work item component breaking navigation fixed (#3036)
* b4f963325 fix(codebases): remove createdAt and pushedAt filter (#3054)