### PR TITLE
status-api pulling from quay for staging

### DIFF
--- a/dsaas-services/status-api.yaml
+++ b/dsaas-services/status-api.yaml
@@ -7,7 +7,7 @@ services:
   environments:
   - name: staging
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/openshiftio/zabbix-status-api
+      IMAGE: quay.io/openshiftio/rhel-openshiftio-zabbix-status-api
   - name: production
     parameters:
       IMAGE: prod.registry.devshift.net/osio-prod/openshiftio/zabbix-status-api


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.