### PR TITLE
Deploy che-starter into prod from Quay

### DIFF
--- a/dsaas-services/che-starter.yaml
+++ b/dsaas-services/che-starter.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 355e74f8077ace2f1f7c28c2661293f0e5f32a82
+- hash: 70de15befd33c934ed74e47e2a33902a2a614648
   hash_length: 7
   name: che-starter
   path: /openshift-template/che-starter.app.yaml
@@ -10,4 +10,4 @@ services:
       IMAGE: quay.io/openshiftio/rhel-almighty-che-starter
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/almighty/che-starter
+      IMAGE: quay.io/openshiftio/rhel-almighty-che-starter


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.