### PR TITLE
Deploy che-tenant-maintainer into prod from Quay

### DIFF
--- a/dsaas-services/che-tenant-maintainer.yaml
+++ b/dsaas-services/che-tenant-maintainer.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: c4da54364cb4fe0e8add6064f0f462a126d35ba1
+- hash: 56a5579d005c28eeaebd575a905eadc986b459dd
   hash_length: 7
   name: che-tenant-maintainer
   path: /openshift/che-tenant-maintainer.app.yml
@@ -10,4 +10,4 @@ services:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-tenant-che-migration
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-tenant-che-migration
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-tenant-che-migration


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay, we can now promote to prod.

Note that the images are no longer being pused to the devshift registry, so if this PR is not merged, please make sure that in the next hash update you are also updating the image to be pulled from quay, instead of from the devshift registry.