### PR TITLE
tenant-log-indirector pulling from quay for staging

### DIFF
--- a/dsaas-services/tenant-log-indirector.yaml
+++ b/dsaas-services/tenant-log-indirector.yaml
@@ -4,3 +4,7 @@ services:
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/openshiftio/tenant-log-indirector
   hash_length: 6
+  environments:
+  - name: staging
+    parameters:
+      IMAGE: quay.io/openshiftio/openshiftio-tenant-log-indirector


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for
the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build
scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO
build scripts push to Quay. Merge the project's repo PR only after
merging this one.