### PR TITLE
Update core

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 953e5b95e2c127ea8da77d8b18fed1935e9a9828
+- hash: a4d9061b1b35a4e7acef28da0dc4bc80f39a72bb
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
**commit** https://github.com/fabric8-services/fabric8-wit/commit/cefe36a2e18a10e4cced158089d2874d28b77233
**Author:** Rohit Kumar Rai <rohitkrai03@gmail.com>
**Date:**   Wed Jul 11 17:54:40 2018 +0530

Changed SHA checksum for dep-darwin-amd64 and setting UNAME_S variable (https://github.com/fabric8-services/fabric8-wit/issues/2163)

- For macOS dep package was updated with a new SHA. This SHA value is checked in `Makefile` with a hardcoded SHA checksum to verify dep package.
- Updated the SHA value to new one.
- Added initialization of `$(UNAME_S)` variable `UNAME_S=$(shell uname -s)` since it was being used but never set which lead to explicitly exporting the variable from shell.

Similar PR for fabric8-auth - https://github.com/fabric8-services/fabric8-auth/pull/549

Note: We can probably look into automating the process where SHA value is fetched dynamically instead of hard coding.

**commit** https://github.com/fabric8-services/fabric8-wit/commit/f13e0949b990c8e9aa07051458b19986d6f83306
**Author:** Elliott Baron <ebaron@redhat.com>
**Date:**   Wed Jul 11 13:46:08 2018 -0400

Add parameter to Delete Space to skip deleting OpenShift resources (https://github.com/fabric8-services/fabric8-wit/issues/2121)

When a user resets their environment, the front-end makes calls to the Delete Space API and Clean Tenant API. It makes these calls asynchronously, and due to both APIs acting on the same resources, I suspect this is the reason we are seeing a variety of errors in openshiftio/openshift.io#3500.

Since the Clean Tenant API cleans out the user's entire namespaces, it is not necessary in this case for Delete Space to delete anything from OpenShift. This PR adds an optional parameter skipCluster, to the Delete Space API, which if true, will not attempt to delete any deployments from OpenShift. The front-end could then use this parameter only when resetting the user's environment. An alternative would be for the front-end to synchronize between deleting spaces and calling Clean Tenant, but this would be less efficient.

Fixes (partially): openshiftio/openshift.io#3500

**commit** https://github.com/fabric8-services/fabric8-wit/commit/cb85aa70a013c6cfcc9905d6facb95135e7f6bbe
**Author:** Ibrahim Jarif <jarifibrahim@gmail.com>
**Date:**   Fri Jul 13 12:57:43 2018 +0530

Refactor search_blackbox_test.go (https://github.com/fabric8-services/fabric8-wit/issues/2148)

**commit** eae146f7d3cdf1d6c40588608e60d688aaf6ad83
**Author:** Dhriti Shikhar <dhriti.shikhar.rokz@gmail.com>
**Date:**   Fri Jul 13 16:55:40 2018 +0530

Increase paging limit (https://github.com/fabric8-services/fabric8-wit/issues/2166)

**commit** https://github.com/fabric8-services/fabric8-wit/commit/d1988136b210b9dc71316cdd10677b48b531dccc
**Author:** Baiju Muthukadan <baiju.m.mail@gmail.com>
**Date:**   Fri Jul 13 17:46:12 2018 +0530

Revert "List work items part of child iterations (https://github.com/fabric8-services/fabric8-wit/issues/2146)" (https://github.com/fabric8-services/fabric8-wit/issues/2168)

This reverts commit 68996d1555a29a9ef310403403855b47559d5a71.


This is required to address #3974

**commit** https://github.com/fabric8-services/fabric8-wit/commit/a4d9061b1b35a4e7acef28da0dc4bc80f39a72bb
**Author:** Michael Kleinhenz <kleinhenz@redhat.com>
**Date:**   Fri Jul 13 16:24:37 2018 +0200

feat(boardview): Board View for WIT. (https://github.com/fabric8-services/fabric8-wit/issues/2111)