### PR TITLE
Deploy jenkins-idler and jenkins-proxy into prod from Quay

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -11,7 +11,7 @@ services:
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-idler
-- hash: 6e9fcefc0451bccbfeaa07b825d309b9dc9eb495
+- hash: a6e9c5c1f9ba7cd6417f9e020cddf49644e16d67
   hash_length: 6
   name: fabric8-jenkins-proxy
   path: /openshift/jenkins-proxy.app.yaml
@@ -19,7 +19,7 @@ services:
   environments:
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-jenkins-proxy
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-proxy
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-proxy

--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e501e24a559a261eb48afd3aab48364dd3690a33
+- hash: de2fc544b53e87003a7e81b6968961ab26eac55c
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml
@@ -7,7 +7,7 @@ services:
   environments:
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-jenkins-idler
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-idler
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-idler


### PR DESCRIPTION
Since these two projects have been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.