### PR TITLE
Deploy tenant-log-indirector into prod from Quay

### DIFF
--- a/dsaas-services/tenant-log-indirector.yaml
+++ b/dsaas-services/tenant-log-indirector.yaml
@@ -1,10 +1,14 @@
 services:
-- hash: ee1ae47ff66774c32fd7a77174c5fef3598fc2bc
+- hash: ef5c8a670bf967dfd3cbf37afdce76e4a8c85c9e
   name: tenant-log-indirector
   path: /openshift/OpenShiftTemplate.yml
   url: https://github.com/openshiftio/tenant-log-indirector
   hash_length: 6
   environments:
+  - name: production
+    parameters:
+      IMAGE quay.io/openshiftio/openshiftio-tenant-log-indirector
   - name: staging
     parameters:
-      IMAGE: quay.io/openshiftio/openshiftio-tenant-log-indirector
+      IMAGE quay.io/openshiftio/openshiftio-tenant-log-indirector
+

--- a/dsaas-services/tenant-log-indirector.yaml
+++ b/dsaas-services/tenant-log-indirector.yaml
@@ -7,8 +7,8 @@ services:
   environments:
   - name: production
     parameters:
-      IMAGE quay.io/openshiftio/openshiftio-tenant-log-indirector
+      IMAGE: quay.io/openshiftio/openshiftio-tenant-log-indirector
   - name: staging
     parameters:
-      IMAGE quay.io/openshiftio/openshiftio-tenant-log-indirector
+      IMAGE: quay.io/openshiftio/openshiftio-tenant-log-indirector
 


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.