### PR TITLE
Deploy rh-che into prod from Quay

### DIFF
--- a/dsaas-services/rh-che6.yaml
+++ b/dsaas-services/rh-che6.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 7d88e4900d0452eec817bdb008368ae64c7a7b25
+- hash: 23f6a5a7f62dd4a7a41ca94fd437556553b8a071
   hash_length: 7
   name: rh-che6
   path: /openshift/rh-che.app.yaml
@@ -10,4 +10,4 @@ services:
       IMAGE: quay.io/openshiftio/rhel-che-rh-che-server
   - name: production
     parameters:
-      IMAGE: prod.registry.devshift.net/osio-prod/che/rh-che-server
+      IMAGE: quay.io/openshiftio/rhel-che-rh-che-server


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.