### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 4247ed7b2ef622817b622819c5f09005811ae3aa
+- hash: 754c1cf51ea3936b29551611d27699975e4f8720
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 754c1cf51 fix(version): update fabric8-planner to 0.50.26 (#3159)
* 6924d6919 fix(launcher): removes validate* functions from dependency check service and changes ngx-forge to ngx-launcher (#3130)
* 97ee1074f fix(my-spaces): introduce case insensitive filtering (#3077)
* 2f3979be2 fix(codebases): fix opening workspaces in a new tab (#2972)