### PR TITLE
osd-monitor-poc pulling from quay for staging

### DIFF
--- a/dsaas-services/osd-monitor-poc.yaml
+++ b/dsaas-services/osd-monitor-poc.yaml
@@ -3,4 +3,18 @@ services:
   name: osd-monitor-poc
   path: /osd-monitor.yml
   url: https://github.com/redhat-developer/osd-monitor-poc/
-  hash_length: 6
+  hash_length: 7
+  environments:
+  - name: staging
+    parameters:
+      IMAGE_PCP_CENTRAL_LOGGER: quay.io/openshiftio/rhel-perf-pcp-central-logger
+      IMAGE_PCP_CENTRAL_WEBAPI: quay.io/openshiftio/rhel-perf-pcp-central-webapi
+      IMAGE_PCP_WEBAPI_GUARD: quay.io/openshiftio/rhel-perf-pcp-webapi-guard
+      IMAGE_PCP_POSTGRESQL: quay.io/openshiftio/rhel-perf-pcp-postgresql-monitor
+      IMAGE_OSO_CENTRAL_LOGGER: quay.io/openshiftio/rhel-perf-oso-central-logger
+      IMAGE_OSO_CENTRAL_WEBAPI_GUARD: quay.io/openshiftio/rhel-perf-oso-central-webapi-guard
+      IMAGE_PCP_BAYESIAN_CENTRAL_LOGGER: quay.io/openshiftio/rhel-perf-pcp-bayesian-central-logger
+      IMAGE_PCP_CENTRAL_WEBAPI: quay.io/openshiftio/rhel-perf-pcp-central-webapi
+      IMAGE_PCP_BAYESIAN_WEBAPI_GUARD: quay.io/openshiftio/rhel-perf-pcp-bayesian-webapi-guard
+  - name: production
+    hash_length: 6


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for
the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build
scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO
build scripts push to Quay. Merge the project's repo PR only after
merging this one.