### PR TITLE
keycloak pulling from quay for staging

### DIFF
--- a/keycloak-services/keycloak.yaml
+++ b/keycloak-services/keycloak.yaml
@@ -3,9 +3,10 @@ services:
   name: keycloak-deployment
   path: /openshift/keycloak.app.yaml
   url: https://github.com/fabric8-services/keycloak-deployment
-  hash_length: 6
+  hash_length: 7
   environments:
   - name: production
+    hash_length: 6
     parameters:
       REPLICAS: 3
       OPERATING_MODE: clustered
@@ -14,9 +15,9 @@ services:
     parameters:
       REPLICAS: 3
       OPERATING_MODE: clustered
-      IMAGE: prod.registry.devshift.net/osio-prod/fabric8-services/keycloak-postgres
+      IMAGE: quay.io/openshiftio/rhel-fabric8-services-keycloak-postgres
   - name: appsec
+    hash_length: 6
     parameters:
       REPLICAS: 3
       OPERATING_MODE: clustered
-


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for
the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build
scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO
build scripts push to Quay. Merge the project's repo PR only after
merging this one.