### PR TITLE
add rhche-redirector deployment

### DIFF
--- a/dsaas-services/rhche-redirector.yaml
+++ b/dsaas-services/rhche-redirector.yaml
@@ -1,0 +1,6 @@
+services:
+- hash: master
+  name: rhche-redirector
+  path: homeless-templates/rhche-redirector.yaml
+  url: https://github.com/openshiftio/saas-openshiftio/
+  hash_length: 6

--- a/dsaas-services/rhche-redirector.yaml
+++ b/dsaas-services/rhche-redirector.yaml
@@ -4,3 +4,12 @@ services:
   path: homeless-templates/rhche-redirector.yaml
   url: https://github.com/openshiftio/saas-openshiftio/
   hash_length: 6
+  environments:
+  - name: staging
+    parameters:
+      REPLICAS: 1
+      IMAGE: quay.io/openshiftio/rhel-base-nginx-redirector
+  - name: production
+    parameters:
+      REPLICAS: 3
+      IMAGE: quay.io/openshiftio/rhel-base-nginx-redirector

--- a/homeless-templates/rhche-redirector.configmap.yaml
+++ b/homeless-templates/rhche-redirector.configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rhche-redirector
+data:
+  redirector.destination: "https://che.openshift.io"
+  redirector.type: permanent

--- a/homeless-templates/rhche-redirector.yaml
+++ b/homeless-templates/rhche-redirector.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: rhche-redirector
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    generation: 1
+    labels:
+      run: rhche-redirector
+    name: rhche-redirector
+  spec:
+    replicas: 1
+    selector:
+      run: rhche-redirector
+    strategy:
+      resources:
+        requests:
+          cpu: 20m
+          memory: 20Mi
+        limits:
+          cpu: 200m
+          memory: 200Mi
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          run: rhche-redirector
+      spec:
+        containers:
+        - env:
+          - name: REDIRECTOR_DESTINATION
+            valueFrom:
+                configMapKeyRef:
+                  name: rhche-redirector
+                  key: redirector.destination
+          - name: REDIRECTOR_TYPE
+            valueFrom:
+                configMapKeyRef:
+                  name: rhche-redirector
+                  key: redirector.type
+          image: prod.registry.devshift.net/osio-prod/base/nginx-redirector:${IMAGE_TAG}
+          imagePullPolicy: Always
+          name: redirector
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    name: rhche-redirector
+  spec:
+    ports:
+    - name: "8080"
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      run: rhche-redirector
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+parameters:
+- name: IMAGE_TAG
+  value: "latest"

--- a/homeless-templates/rhche-redirector.yaml
+++ b/homeless-templates/rhche-redirector.yaml
@@ -49,7 +49,7 @@ objects:
                 configMapKeyRef:
                   name: rhche-redirector
                   key: redirector.type
-          image: prod.registry.devshift.net/osio-prod/base/nginx-redirector:${IMAGE_TAG}
+          image: image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: redirector
           ports:
@@ -82,5 +82,7 @@ objects:
   status:
     loadBalancer: {}
 parameters:
+- name: IMAGE
+  value: quay.io/openshiftio/rhel-base-nginx-redirector
 - name: IMAGE_TAG
   value: "latest"


### PR DESCRIPTION
This deployment's sole purpose is to receive traffic at https://rhche.openshift.io and to a 301/permanent redirect to https://che.openshift.io