### PR TITLE
Do not return an error if X out of Y collaborators exist.

### DIFF
--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 840beef5c8614b1902c8771c09c088dd609581f3
+- hash: 65da44ff61c5840758f325f15864c0c0cf6d0456
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/


### PR DESCRIPTION
fixes https://github.com/openshiftio/openshift.io/issues/4011
by deploying https://github.com/fabric8-services/fabric8-auth/pull/558