### PR TITLE
remove IMAGE_PCP_BAYESIAN_WEBAPI_GUARD image param

### DIFF
--- a/dsaas-services/osd-monitor-poc.yaml
+++ b/dsaas-services/osd-monitor-poc.yaml
@@ -15,6 +15,5 @@ services:
       IMAGE_OSO_CENTRAL_WEBAPI_GUARD: quay.io/openshiftio/rhel-perf-oso-central-webapi-guard
       IMAGE_PCP_BAYESIAN_CENTRAL_LOGGER: quay.io/openshiftio/rhel-perf-pcp-bayesian-central-logger
       IMAGE_PCP_CENTRAL_WEBAPI: quay.io/openshiftio/rhel-perf-pcp-central-webapi
-      IMAGE_PCP_BAYESIAN_WEBAPI_GUARD: quay.io/openshiftio/rhel-perf-pcp-bayesian-webapi-guard
   - name: production
     hash_length: 6


### PR DESCRIPTION
remove IMAGE_PCP_BAYESIAN_WEBAPI_GUARD parameter from dsaas osd monitor
because this that image is not part of dsaas osd monitoring


cc: @jmelis 