### PR TITLE
reomve IMAGE_PCP_BAYESIAN_CENTRAL_LOGGER from osd

### DIFF
--- a/dsaas-services/osd-monitor-poc.yaml
+++ b/dsaas-services/osd-monitor-poc.yaml
@@ -13,7 +13,6 @@ services:
       IMAGE_PCP_POSTGRESQL: quay.io/openshiftio/rhel-perf-pcp-postgresql-monitor
       IMAGE_OSO_CENTRAL_LOGGER: quay.io/openshiftio/rhel-perf-oso-central-logger
       IMAGE_OSO_CENTRAL_WEBAPI_GUARD: quay.io/openshiftio/rhel-perf-oso-central-webapi-guard
-      IMAGE_PCP_BAYESIAN_CENTRAL_LOGGER: quay.io/openshiftio/rhel-perf-pcp-bayesian-central-logger
       IMAGE_PCP_CENTRAL_WEBAPI: quay.io/openshiftio/rhel-perf-pcp-central-webapi
   - name: production
     hash_length: 6


### PR DESCRIPTION
remove IMAGE_PCP_BAYESIAN_CENTRAL_LOGGER from dsaas osd monitoring as it is part of bayesian-monitor.yml

cc: @jmelis 