### PR TITLE
Fix REPLICAS in rhche-redirector template

### DIFF
--- a/homeless-templates/rhche-redirector.yaml
+++ b/homeless-templates/rhche-redirector.yaml
@@ -13,7 +13,7 @@ objects:
       run: rhche-redirector
     name: rhche-redirector
   spec:
-    replicas: ${REPLICAS}
+    replicas: ${{REPLICAS}}
     selector:
       run: rhche-redirector
     strategy:


### PR DESCRIPTION
This is trying to solve this problem:
https://ci.centos.org/job/devtools-saas-openshiftio-promote-to-prod/986/console

    service "rhche-redirector" configured
    Error from server: unrecognized type: int32
    Failed applying dsaas-20180726_102347/rhche-redirector.yaml, failing job
    Build step 'Execute shell' marked build as failure

As specified in
https://docs.openshift.com/container-platform/3.9/dev_guide/templates.html:

    When using the ${{PARAMETER_NAME}} syntax only a single parameter
    reference is allowed and leading/trailing characters are not permitted.
    The resulting value will be unquoted unless, after substitution is
    performed, the result is not a valid json object. If the result is not a
    valid json value, the resulting value will be quoted and treated as a
    standard string.