### PR TITLE
Update fabric8-tenant-jenkins version to 4.0.94

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 69fd1bd60c32b88b3644f50ba5b0083cd26688b8
+- hash: 471ae0cdb49b03f0887077691c95df190525c541
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
The change includes the updated jenkins-sync plugin details -  https://github.com/openshiftio/openshift.io/issues/3969 "Build not getting triggered when doing a master commit in case of different app and repo name".

cc: @aslakknutsen 