### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: a4093c42321a12e0b963b14027683ffb4931c31b
+- hash: 79c0b5e758893747abb465d74fad151a50ef8ee1
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
commit https://github.com/fabric8-services/fabric8-wit/commit/master/e53e3d309b07b9a366fbd07c5f51e4f22bab7890
Author: Tina Kurian <tkurian@redhat.com>
Date:   Fri Jul 27 08:45:09 2018 -0400

Create new 'endpoints' endpoint (fabric8-services/fabric8-wit#2169)

See https://github.com/fabric8-services/fabric8-wit/issues/521

The newly introduced root endpoint will display all endpoints following the JSONAPI format. Currently, this endpoint will not display endpoints which contain parameters. Improvements would including storing the parsed specification and names into a table to avoid parsing the specification on the fly and allow for querying.

Names are created two different ways;

1. _path segments_
The api will default to populating the name using segments of the related path.

E.g.]
```
"codebases_che_start": {
        "links": {
                "related": "/codebases/che/start"
        }
}
```
2. _x-tags_
If an x-tag is present in the swagger specification, the x-tag value will be used in substitution.

E.g.]
```
"current_user": {
        "links": {
                "related": "/user"
        }
}
```

Co-authored-by: Konrad Kleine <193408+kwk@users.noreply.github.com>

commit https://github.com/fabric8-services/fabric8-wit/commit/master/5317c1df75ad8022c7cce765ae4d0193b3e1e34f
Author: Elliott Baron <ebaron@redhat.com>
Date:   Mon Jul 30 16:09:32 2018 -0400

Add object count quotas to environment stats (fabric8-services/fabric8-wit#2175)

Currently, the deployments page shows CPU and memory resource usage and limits for each environment. There are also quotas enforced for the number of certain types of objects in each namespace. Hitting these quotas can prevent further deployments to those environments, so this information is useful to show to the user.

This PR adds usage and limits, for each type of object that has an active quota, to the data returned by the ShowEnvironments API. After discussing the design with UX, we agreed to show only object types that have a quota set up. The possible object types are: pods, replication controllers, resource quotas, services, secrets, config maps, persistent volume claims, and image streams. Currently, my OpenShift starter account has only quotas enabled for replication controllers, services, secrets and persistent volume claims.

commit https://github.com/fabric8-services/fabric8-wit/commit/master/79c0b5e758893747abb465d74fad151a50ef8ee1
Author: Tina Kurian <tkurian@redhat.com>
Date:   Tue Jul 31 03:50:58 2018 -0400

Serve endpoints API under /api and fix missing URL schema for relationship links of endpoints (fabric8-services/fabric8-wit#2194)

With this PR the endpoints (see fabric8-services/fabric8-wit#521) are served under `/api` and each endpoint relationship link has a proper URL-schema prefix.

The `/api` temporarily redirects to `/api/endpoints`.

Co-authored-by: Konrad Kleine 193408+kwk@users.noreply.github.com