### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 656d47a544a7ec56dbaa34ea769cb0f44c7f7021
+- hash: de274224c33908f9a77e1eabdfbc6b401db79ec5
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* de274224c fix(version): update fabric8-planner to 0.51.0
* 63b8af50d fix(cors): remove `api` subdomain from wit api url (#3154)
* 4cd7bcc73 test(codebases-item-actions): fix failing unit tests (#3203)
* 957e209d4 fix(codebases): prevent new tab opening when creating workspace via dropdown menu (#3193)
* 17833978d fix(home): clean up unused code (#3185)
* 2eb7e4d33 fix(recent-spaces): Recent spaces widget to show only one instance of a space (#3166)
* 93e0f3f57 fix(profile): refactor work items component to display work items for profile user (#3178)
* 5e2074265 fix(collaborators): fixed component height and vertical scroll enabled for infinite scroll (#3180)
* f5db2f4b1 fix(package): update ngx-fabric8-wit to 6.21.0 (#3183)
* df4c208be fix(workitemwidget): group feature flag to use page-cached feature-flag (#3182)
* 457622936 fix(feature-flag): update to latest version (#3181)