### PR TITLE
Update Jenkins-Proxy

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -11,7 +11,7 @@ services:
   - name: staging
     parameters:
       IMAGE: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-idler
-- hash: a6e9c5c1f9ba7cd6417f9e020cddf49644e16d67
+- hash: 99399c90d426140e31f442ab1c34eb77cc58471c
   hash_length: 6
   name: fabric8-jenkins-proxy
   path: /openshift/jenkins-proxy.app.yaml


### PR DESCRIPTION
This update addresses 504 gateway error that is shown when Jenkins
takes too long to boot.