### PR TITLE
Update core deployment to 633aee2cd

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 79c0b5e758893747abb465d74fad151a50ef8ee1
+- hash: 633aee2cd9783ca7a2e7aa62c35091fba134d8df
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
commit https://github.com/fabric8-services/fabric8-wit/commit/02cbf7ee952b8338cc273295312bae172acd4781
Author: Tina Kurian <tkurian@redhat.com>
Date:   Wed Aug 1 08:18:12 2018 -0400

deprecate endpoint userspace (fabric8-services/fabric8-wit#2200)

See https://github.com/openshiftio/openshift.io/issues/4046

Removing the userspace endpoint. It was used as a hack in the past in order to get data in from tenant jenkins.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/6ac0ff63f34dd365ac2417269157f5af8fa476e1
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Thu Aug 2 11:20:31 2018 +0200

Move links of a relationship outside of the data-section (fabric8-services/fabric8-wit#2205)

Moved links to an
* area
* iteration
* user
* board-column

  relationship out of the `data` section in the relationship and into their own `links` section alongside the `data` section.

Removed links as a whole from area/iteration/label/user/board-column relationship**s** (plural!), because a link as we have it can only link to an individual entity and not to all entities that are part for the relationship. For this to work we would need to have support for links to the relationship of a resource, so for example:

* /api/workitems/1234/author
* /api/workitems/1234/relationship/author

This change fixes some of the problems with links appearing in the wrong place. This is to make the API more JSONAPI compliant. It is not the final JSONAPI compliance I'm striving for but a reviewable step in that direction.

## Background

JSONAPI doesn't allow for 'links' in the `data` section of a relationship as in this example:

```yaml
{
  "data": {
    "type": "articles",
    "id": "1",
    "relationships": {
      "author": {
        "data": {
          "type": "people",
          "id": "9",
          "links": {
            "self": "http://example.com/articles/1/relationships/author",
            "related": "http://example.com/articles/1/author"
          }
        }
      }
    }
  }
}
```

But moving the `links` section next to the `data` makes it a valid JSONAPI response:

```yaml
{
  "data": {
    "type": "articles",
    "id": "1",
    "relationships": {
      "author": {
        "links": {
          "self": "http://example.com/articles/1/relationships/author",
          "related": "http://example.com/articles/1/author"
        },
        "data": {
          "type": "people",
          "id": "9"
        }
      }
    }
  }
}
```




You can try out the above examples here: https://www.jsonschemavalidator.net/

We did include a links in the `data` section in many places.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/6687a95e87c1c2e91595c0d23204f7937c8a92c1
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Thu Aug 2 13:05:04 2018 +0200

better error message in simple type and a bit relaxed integer handling (fabric8-services/fabric8-wit#2204)

Integers can now be given as floats as long as they have no digits after the decimal point. Some error messages for simple types have been improved.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/e05f5f309f9fb0922fec05c1c499c09404d221d2
Author: Michael Kleinhenz <kleinhenz@redhat.com>
Date:   Fri Aug 3 09:10:53 2018 +0200

fix(templates): fix child wit order. (fabric8-services/fabric8-wit#2201)

Fixes the order of the possible child WIs in the template. This will be reflected in the order of selection in the UI.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/124df23695bdaebd4a21dab8ecd0665ed2139fab
Author: Michael Kleinhenz <kleinhenz@redhat.com>
Date:   Mon Aug 6 14:53:49 2018 +0200

Updating states on Agile template, relaxing importer (fabric8-services/fabric8-wit#2170)

This adds some states to the list of available states on Themes and Epics in the Agile template. It also relaxes the template importer so adding new values to an existing enum is now allowed when editing templates. Note that removing values is still not possible without migration and further changes on the code.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/4e942ed96358130e3d3e2c0affa8ffaf970bb287
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Mon Aug 6 16:35:25 2018 +0200

Add constants test (fabric8-services/fabric8-wit#2216)

This adds a unit-test test to check that workitem type constants are not changed accidentally.

This makes usage of constants in tests more safe as discussed in today's meeting with @jarifibrahim and @michaelkleinhenz .

---

commit https://github.com/fabric8-services/fabric8-wit/commit/7d8ca2379dc12f2b00ac97e88339a7e1619459ea
Author: Aslak Knutsen <aslak@4fs.no>
Date:   Mon Aug 6 19:27:36 2018 +0200

Update OSO Proxy URL to external route name (fabric8-services/fabric8-wit#2219)

Fixes openshiftio/openshift.io#4125

---

commit https://github.com/fabric8-services/fabric8-wit/commit/2f7c863b2f057081bf2b0c65cdc4d8bed4aa1cd1
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Tue Aug 7 08:07:23 2018 +0200

Serve swagger under /api/swagger.json and swagger-ui (fabric8-services/fabric8-wit#2217)

This serves the generated `swagger.json` under `/api/swagger.json` and replaces the host with the current setting from `config.GetHTTPAddress()`. This should make the swagger output compatible with whatever host it is running on (local, prod-preview, prod, ...).

I've also added a swagger-ui container that starts up on `make dev` and is served at [http://localhost:8081/](http://localhost:8081/):

See also fabric8-services/fabric8-wit#165 for an old version of this.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/633aee2cd9783ca7a2e7aa62c35091fba134d8df
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Tue Aug 7 10:53:20 2018 +0200

Replace swagger host with request host and adjust scheme (fabric8-services/fabric8-wit#2220)

As a follow up for #2217 this change will properly replace the host (currently always `host: "0.0.0.0:8080",`) in the [generated swagger file](https://api.prod-preview.openshift.io/api/swagger.json) with the host of the request that tries to access the swagger file. We strip off the `http://` or `https://` prefix because that's handled in the swagger `schemes` section.

We also set the scheme to `https` if the current request was made using `https://`.
