### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 633aee2cd9783ca7a2e7aa62c35091fba134d8df
+- hash: 18d2d478363ef2b2f4917db8d532afed80af0c9d
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
commit https://github.com/fabric8-services/fabric8-wit/commit/18d2d478363ef2b2f4917db8d532afed80af0c9d (upstream/master)
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Tue Aug 7 13:29:00 2018 +0200

Fix swagger scheme (fabric8-services/fabric8-wit#2221)
    
A fixup up for fabric8-services/fabric8-wit#2217 to properly adjust the schemes defined in swagger.
    
Previously the X-Forwarded-Proto wasn't respected but now it is.