### PR TITLE
Update fabric8-tenant-jenkins version to 4.0.99

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: cd3e1de58b5309be775895d3f966bcaf60b3a13d
+- hash: 6960a4d48cd6b550a90cbb87da443578e8839c6c
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
This includes changes for 

1. https://github.com/openshiftio/openshift.io/issues/3982 - PR https://github.com/fabric8io/openshift-jenkins-s2i-config/pull/185 : Bayesian plugin update
2. https://github.com/openshiftio/openshift.io/issues/4006 - PR https://github.com/fabric8io/openshift-jenkins-s2i-config/pull/186 : Fixing failing plugin version due to transitive dependencies

cc: @aslakknutsen 