### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 18d2d478363ef2b2f4917db8d532afed80af0c9d
+- hash: 2661cf80beff4aad9233b4a728b37b35e6298bcb
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
Provide join lock down  (fabric8-services/fabric8-wit#2211)
    
This includes an extra-condition in the `ON` part of the table `JOINS` for areas, codebases and iterations to only join those tables filtered by their space ID.
        
See fabric8-services/fabric8-wit#2210.