### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: eac672332705ed5cc493528ed7acdfe53e2157d5
+- hash: 152a20c72af8b855f4caec1355abbce863192fb5
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/

--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2661cf80beff4aad9233b4a728b37b35e6298bcb
+- hash: eac672332705ed5cc493528ed7acdfe53e2157d5
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
commit https://github.com/fabric8-services/fabric8-wit/commit/9cd0a22f7b4763510d6e20c661a429a4a53a336d
Author: nurali-techie <nurali.techie@gmail.com>
Date:   Wed Aug 8 10:54:35 2018 +0530

Codebase can search git@github.. type codebase URLs. (fabric8-services/fabric8-wit#2215)

Fixes : https://github.com/openshiftio/openshift.io/issues/4080

---

commit https://github.com/fabric8-services/fabric8-wit/commit/5dd4b21ddfcf3abebf6868879c27aed5dcaaa9da
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Wed Aug 8 10:18:53 2018 +0200

have golden files for work item type groups from agile template (fabric8-services/fabric8-wit#2223)

The work item type groups of the agile template haven't been tested so far. This file dumps them to their own golden files.

This is important to recognize changes, when somebody changes the type groups in the YAML file. For example in fabric8-services/fabric8-wit#2222 the changes are unnoticed which is bad.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/b82520bb7317e89b8382511523309dc6c465bf41
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Wed Aug 8 15:04:16 2018 +0200

Add support for description in work item type group (fabric8-services/fabric8-wit#2225)

To support fabric8-services/fabric8-wit#2222 where @Preeticp wants to add info tips texts to work item type groups. Here I've added just one description (as pointed out here: https://github.com/fabric8-services/fabric8-wit/pull/2222#issuecomment-411048527) to see that it works. @Preeticp can do the rest in her PR.

---

commit https://github.com/fabric8-services/fabric8-wit/commit/eac672332705ed5cc493528ed7acdfe53e2157d5
Author: Preeti Chandrashekar <preetipagad@gmail.com>
Date:   Wed Aug 8 20:01:41 2018 +0530

infotips for WITs and WITGs for agile an SDD (fabric8-services/fabric8-wit#2222)

This adds infotips for work item types and work item type groups to the Agile and SDD templates.

Co-authored-by: Konrad Kleine 193408+kwk@users.noreply.github.com

---

commit https://github.com/fabric8-services/fabric8-wit/commit/152a20c72af8b855f4caec1355abbce863192fb5
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Wed Aug 8 16:57:53 2018 +0200

event cleanup (code+golden files) (fabric8-services/fabric8-wit#2226)

There were places inside of the event system that dealt with work item fields by name and not by their type. Here's what's done by this change.

1. We only distinguish between single-value (`workitem.SimpleType` and `workitem.EnumType`) and multi-value (`workitem.ListType`) fields in the work item repository.
2. We use the existing `workitem.FieldType.ConvertFromModel` function to convert stored values from the DB into the model space. Previously this was done manually and everything was converted to a string.
3. The events JSONAPI no longer expects old and new values to be strings all the time. Instead values can be of any type. Have a look at the `controller/test-files/event/list/ok-kindFloat.res.payload.golden.json` and `controller/test-files/event/list/ok-kindInt.res.payload.golden.json` files to see that effect.
4. Added event system tests for simple values (those that are not relationships) in a list or a single field.

This work in this change was initially done in fabric8-services/fabric8-wit#2212 and fabric8-services/fabric8-wit#2213 to split up code and golden file changes. It has been reviewed there.