### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 152a20c72af8b855f4caec1355abbce863192fb5
+- hash: e258355bcf2bf0fa588327bb3a0d08456d9fa1b5
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
commit https://github.com/fabric8-services/fabric8-wit/commit/e258355bcf2bf0fa588327bb3a0d08456d9fa1b5
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Wed Aug 8 19:10:39 2018 +0200

Revert "event cleanup (code+golden files) (fabric8-services/fabric8-wit#2226)" (fabric8-services/fabric8-wit#2227)
    
This reverts commit https://github.com/fabric8-services/fabric8-wit/commit/152a20c and restores the old event behavior.
    
We have several issues on the UI and presumably they come from the reverted commit.

This should address https://errortracking.prod-preview.openshift.io/openshift_io/fabric8-ui/issues/6717/