### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1018c6fafa324ae7e965557c6186f3b365fca810
+- hash: 0059963a3f11c798a67dae4841ecb729eb0b9e54
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 0059963a3 fix(recent-spaces): fix f8-card-body-lg less rules to properly fill recent spaces widget
* c82ced5df fix(import-flow): makes maven the only pipeline choice again (#3245)
* 2f3a0bdaf fix(tests): async tests using done function (#3241)
* 418fc2b3a fix(recent-pipelines-widget): change to show all recent pipelines and clean up code (#3195)