### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e258355bcf2bf0fa588327bb3a0d08456d9fa1b5
+- hash: 0ea68b455cc9ebb0b0d876534eaf0f101b1b1a47
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
----

commit  https://github.com/fabric8-services/fabric8-wit/commit/35fda853c47fa114dc49cbbccec8b3050a88b2f8
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Fri Aug 10 14:13:37 2018 +0200

Fix migration test (fabric8-services/fabric8-wit#2229)

Last two migration tests were using the wrong index in order to update the work item DB.

----

commit  https://github.com/fabric8-services/fabric8-wit/commit/7e2a8fd8fabe6227b9627533737e813473412068
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Fri Aug 10 14:44:16 2018 +0200

Use create from model function when importing WIT from YAML (fabric8-services/fabric8-wit#2230)

This caused some new fields in the WIT not to be respected by the creator.

----

commit  https://github.com/fabric8-services/fabric8-wit/commit/fe430b134c64f7a0aad38bd58e69ebb0398025f1
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Sat Aug 11 22:56:33 2018 +0200

Add golden files for all work item link types of all space templates (fabric8-services/fabric8-wit#2232)

This adds a golden file for the payload and response of all work item link types defined in all space templates.

----

commit  https://github.com/fabric8-services/fabric8-wit/commit/a84f6a1ab726e02b90248008a1e8a9def6aba7db
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Mon Aug 13 10:38:16 2018 +0200

Add forward and reverse link type description (fabric8-services/fabric8-wit#2231)

This lets us have a forward and reverse description in link types to give helpful text inside the drop down for link types in the UI.

----

commit  https://github.com/fabric8-services/fabric8-wit/commit/0ea68b455cc9ebb0b0d876534eaf0f101b1b1a47
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Mon Aug 13 11:14:45 2018 +0200

Added cico_run_e2e_tests.sh (fabric8-services/fabric8-wit#2235)

We want to have end to end tests checking our PRs and in fabric8-services/fabric8-wit#2197 @rgarg1 is working on how this.

It makes sense to run the end to end tests as a standalone job because the tests can be slow and can output messages that we don't want to see inside of our unit or integration tests.

This change adds a `cico_run_e2e_tests.sh` file that fails all the time and outputs a message. Once the file https://github.com/openshiftio/openshiftio-cico-jobs/blob/master/devtools-ci-index.yaml is adjusted to pick up run the end to end tests using this file, then @rgarg1 can adjust his PR to execute the tests in this `.sh` file.

----
