### PR TITLE
Update Jenkins-Idler

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: de2fc544b53e87003a7e81b6968961ab26eac55c
+- hash: dcf40f21e7354c6f676ce44a863e8b85c30bf909
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
This update of idler removes the code that wakes up content-repository

See: https://github.com/openshiftio/openshift.io/issues/4083