### PR TITLE
Update core to 19c0e19355ac3b0aa8bdd67e8a9e0854a3843ed2

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0ea68b455cc9ebb0b0d876534eaf0f101b1b1a47
+- hash: 19c0e19355ac3b0aa8bdd67e8a9e0854a3843ed2
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
----

commit https://github.com/fabric8-services/fabric8-wit/commit/c2b11841dd2243960c1fe3987941b4da11a1180c
Author: Tina Kurian <tkurian@redhat.com>
Date:   Mon Aug 13 07:37:40 2018 -0400

fixing migration 100 to be consistent with others (fabric8-services/fabric8-wit#2233)

Fixing migration 100 to be consistent with all the other migrations.

----

commit https://github.com/fabric8-services/fabric8-wit/commit/152f697c1a1e6f1908b6ba912a1da30aad8f652c
Author: Ibrahim Jarif <jarifibrahim@gmail.com>
Date:   Tue Aug 14 17:07:36 2018 +0530

Add Users to test fixture (fabric8-services/fabric8-wit#2238)

With this PR, we now have a `tf.Users(n)` function that creates user entities.

----

commit https://github.com/fabric8-services/fabric8-wit/commit/19c0e19355ac3b0aa8bdd67e8a9e0854a3843ed2
Author: Konrad Kleine <193408+kwk@users.noreply.github.com>
Date:   Tue Aug 14 15:35:16 2018 +0200

Restore event cleanup (code+golden files) (fabric8-services/fabric8-wit#2239)

See fabric8-services/fabric8-wit#2226 for the original change that was reverted later in fabric8-services/fabric8-wit#2227.

There were places inside of the event system that dealt with work item fields by name and not by their type. Here's what's done by this change.

1. We only distinguish between single-value (`workitem.SimpleType` and `workitem.EnumType`) and multi-value (`workitem.ListType`) fields in the work item repository.
2. We use the existing `workitem.FieldType.ConvertFromModel` function to convert stored values from the DB into the model space. Previously this was done manually and everything was converted to a string.
3. The events JSONAPI no longer expects old and new values to be strings all the time. Instead values can be of any type. Have a look at the `controller/test-files/event/list/ok-kindFloat.res.payload.golden.json` and `controller/test-files/event/list/ok-kindInt.res.payload.golden.json` files to see that effect.
4. Added event system tests for simple values (those that are not relationships) in a list or a single field.

This work in this change was initially done in fabric8-services/fabric8-wit#2212 and fabric8-services/fabric8-wit#2213 to split up code and golden file changes. It has been reviewed there.

----