### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1bf9fd26bc118b533bb7745c2a5ce6de45e28ed1
+- hash: 902760cd728dd7248b68903c47ab6a845b185cef
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 902760cd7 fix(version): update fabric8-planner to 0.54.0 (#3269)
* ea4113722 fix(getting-started): add type annotations (#3263)
* 6955caa14 fix(cleanup): use skipCluster query parameter when deleting spaces (#3243)
* f9eb5d10f cleanup(http): removed unused http references and updated to httpclient where needed (#3260)
* c49e28218 fix(launcher): update ngx-launcher to 1.0.19 (#3246)