### PR TITLE
Update fabric8-tenant-jenkins version 4.0.106

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e01999ba31bb64efc6668074e1e900d142b5c926
+- hash: 30e353513ff4e9e1f9ea443fcff88efb263c768e
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
This PR will upgrade the fabric8-tenant-jenkins
version to 4.0.106 which have the fix for following

Issue https://github.com/openshiftio/openshift.io/issues/3934
    PR - https://github.com/fabric8-services/fabric8-tenant-jenkins/pull/121

Issue https://github.com/openshiftio/openshift.io/issues/3796
    PR - https://github.com/fabric8-services/fabric8-tenant-jenkins/pull/122