### PR TITLE
Update Core to 677410943faa4c4d403f15f9639a8a15b4c19be9

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1ca1860b8ac8c97de8bb72be82679263b8ddcbed
+- hash: 677410943faa4c4d403f15f9639a8a15b4c19be9
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit git-log-pr.sh 1ca1860b8ac8c97de8bb72be82679263b8ddcbed..upstream/master

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/d00f1960fdd4d67dd293ec2f62165b80275d5f54
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-08-27T14:10:16+02:00

Update dependency to `auth` (and fix tests) (fabric8-services/fabric8-wit#2245)

also: 
- removing all references to `auth.KeycloakPolicy` in
tests, replacing by an array of `string` in the dummy
authz service.
- fix broken test/code on remoteworkitem
- add test to verify preload of User

Fixes fabric8-services/fabric8-wit#2243

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/c4f317aa8ff076ad850100244d36cbb635241b2a
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-08-29T16:01:10+05:30

Update gopkg.lock (fabric8-services/fabric8-wit#2264)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/677410943faa4c4d403f15f9639a8a15b4c19be9
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-03T09:23:34+02:00

Fix searching by board id when the boardcolumns field on a WI is null  (fabric8-services/fabric8-wit#2271)

The problem in fabric8-services/fabric8-wit#2267 was that we were calling a JSONB function `jsonb_array_elements_text` on a JSONB field, namely `system.boardcolumns`, that was `NULL`. That caused a `pq: cannot extract elements from a scalar` error.

## How to reproduce the original bug

The problem can be re-constructed by executing this SQL command:

```sql
SELECT jsonb_array_elements_text(
  '{"system.boardcolumns": null}'::jsonb->'system.boardcolumns'
);
```

This will produce the `cannot extract elements from a scalar`.

## Fixing the problem

If you strip out all `null` values from the object before accessing the field `system.boardcolumns` the error has vanished:

```sql
SELECT jsonb_array_elements_text(
  jsonb_strip_nulls('{"system.boardcolumns": null}'::jsonb)->'system.boardcolumns'
);
```

## Proof that it works with not-`NULL` data

In the above example, the `system.boardcolumns` was purposefully set to `null` but to see it in action with a real array, you can do this:

```sql
SELECT jsonb_array_elements_text(
  jsonb_strip_nulls(
    '{"system.boardcolumns": ["aa089753-9f08-460c-bf18-708046314e5f", "a9cac35d-6b5d-4d2d-9ace-b09e246d42d8"]}'::jsonb
  )->'system.boardcolumns'
);
``` 
This nicely produces the expected results:

```
+--------------------------------------+
| jsonb_array_elements_text            |
|--------------------------------------|
| aa089753-9f08-460c-bf18-708046314e5f |
| a9cac35d-6b5d-4d2d-9ace-b09e246d42d8 |
+--------------------------------------+
```

----

