### PR TITLE
Update auth to 8565a6

### DIFF
--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ec4d00bc1f17c37c11165e50c507802c1cf5968e
+- hash: 8565a61481e5a96384ebc4aa2d0379bbd51e6426
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-auth deploy-commit-to-production.sh ec4d00bc1f17c37c11165e50c507802c1cf5968e..origin/master

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/92d4b86ce773edcbde76d25038cf930303e77871
**Author:** Dipak Pawar (dipakpawar231@gmail.com)
**Date:** 2018-08-28T15:56:18+05:30

chore: add config file to skip validation for minishift folder (fabric8-services/fabric8-auth#626)



----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/f2618448601ef78187f99319f80c11784ce7241e
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-08-28T18:56:55+02:00

Use existing type as query param for listing resources a user has a role in (fabric8-services/fabric8-auth#628)

Replace `spaces` with `openshift.io/resource/space` as
the resource type for spaces so there's no need for
a transation from `spaces`, but keep checking the `type`
query param for invalid values, to avoid
running an expensive query for nothing (and then return
a 400 error)

Also, `openshift.io/resource/space` is a valid query param
 as defined in https://tools.ietf.org/html/rfc3986#section-3.4,
even if it contains `/` characters

Fixes fabric8-services/fabric8-auth#623

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/62cc9ffdeef532c055af606725bd86509c61d918
**Author:** Shane Bryzak (sbryzak@gmail.com)
**Date:** 2018-08-29T21:07:02+10:00

Audit API for validating/updating RPT tokens (fabric8-services/fabric8-auth#561)

Fixes fabric8-services/fabric8-auth#544, Fixes fabric8-services/fabric8-auth#611

Implements an endpoint which allows a token to be audited in respect to the user's privileges for a specified resource ID.  Returns a new RPT token if the current token does not contain the required privileges, or the privileges have expired.  Otherwise returns an empty response if the presented token already contains the up-to-date state of the user's privileges for the resource.

Request:

```
Authorization: Bearer $ACCESS_TOKEN_OR_RPT
POST /api/token/audit?resource_id=c0ee2b94-aee3-4c41-9e15-6fa330ce8e0b
```

Response when a new RPT token has been issued:

```
{
  rpt_token: eyJhbGciOiJ____token___GeFIyvT_sIDyPgYFSR2YCN4_N3CSQPfQYdrQhDGKM7fKLBKnYqAwfUe2OeibQ
}
```

Decoded RPT token:

```
{
  alg: "RS256",
  kid: "aUGv8mQA85jg4V1DU8Uk1W0uKsxn187KQONAGl6AMtc",
  typ: "JWT"
}.
{
  acr: "0",
  allowed-origins:[
   "http://auth.openshift.io",  "http://openshift.io"
  ],
  approved: true,
  aud: "http://openshift.io",
  auth_time: 1535414160,
  azp: "http://openshift.io",
  email: "TestUser-50edff18-6c86-4910-b069-37d68f1c02c1@test.com",
  email_verified: false,
  exp: 1538006160,
  family_name: "",
  given_name: "TestUser-50edff18-6c86-4910-b069-37d68f1c02c1",
  iat: 1535414160,
  iss: "http://auth.openshift.io",
  jti: "109d09ed-91cc-4393-8fa1-bc3187aa40ba",
  name: "TestUser-50edff18-6c86-4910-b069-37d68f1c02c1",
  nbf: 0,
  permissions: [
    {
      resource_set_name: null,
      resource_set_id: "c0ee2b94-aee3-4c41-9e15-6fa330ce8e0b",
      scopes: ["lima"],
      exp: 1535500572
    }
  ],
  preferred_username: "TestUserIdentity-50edff18-6c86-4910-b069-37d68f1c02c1",
  realm_access: {
    roles: [   "uma_authorization"  ]
  },
  resource_access: {
    account: {
      roles: [    "manage-account",    "manage-account-links",    "view-profile"   ]
    },
    broker: {   roles: [    "read-token"   ]  }
  },
  session_state: "",
  sub: "7aca58df-b6e1-4a58-8d3a-600df382dd40",
  typ: "Bearer"
}.
[signature]
--

```



----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/f0b30241acfdbc0ca00cc3dcd2a426816968d24e
**Author:** Shane Bryzak (sbryzak@gmail.com)
**Date:** 2018-08-30T19:23:37+10:00

Add scopes endpoint for resources (fabric8-services/fabric8-auth#635)

* ISSUE-634 added scopes endpoint for resources

Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

* ISSUE-634 test scopes with two separate roles

Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

* ISSUE-634 restructured response

Signed-off-by: Shane Bryzak <sbryzak@gmail.com>


----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/9344288a2c4f9c1d4c070b4f9af46e415e0bf970
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-09-03T13:44:37+02:00

Remove role names and scopes from API (fabric8-services/fabric8-auth#632)

Roles and scopes should not be provided in the response
to the endpoint that lists all resources of a given type
for which the current user has a role, as this may lead
to bad usage of the API. Other endpoints already exists
to check the permissions on a given resource.

Response now looks like this:
````
{
    "data": [{
        "id": "114c89ec-8ff2-4c65-adb4-161c9b505be9",
        "links": {
            "related": "http:///api/resource/114c89ec-8ff2-4c65-adb4-161c9b505be9"
        },
        "type": "resources"
    }, {
        "id": "5d7d3f9b-5a53-4d7e-b321-de3999542626",
        "links": {
            "related": "http:///api/resource/5d7d3f9b-5a53-4d7e-b321-de3999542626"
        },
        "type": "resources"
    }]
}
````

Also: needed to rename the `Read` action to `Show` so that Goa
can generate the `Href` utility function to provide a link to the
resource in the JSON-API response.

Fixes fabric8-services/fabric8-auth#629

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/de034309d4f8610ee20a26adb4a2b77e45d1e4c8
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-09-04T10:11:45+02:00

Improve data isolation in tests (fabric8-services/fabric8-auth#639)

Use test graph attached to current subtest 't'

Also, avoid using space and organization types

Fixes fabric8-services/fabric8-auth#638

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/8565a61481e5a96384ebc4aa2d0379bbd51e6426
**Author:** Dipak Pawar (dipakpawar231@gmail.com)
**Date:** 2018-09-04T16:21:31+05:30

Redirect to specified resource URL after accepting invitation (fabric8-services/fabric8-auth#620)

fixes fabric8-services/fabric8-auth#546

----