### PR TITLE
Update core to 4909a90aef93ad7efc600faa43e7f0037a04de54

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 677410943faa4c4d403f15f9639a8a15b4c19be9
+- hash: 4909a90aef93ad7efc600faa43e7f0037a04de54
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit git-log-pr.sh 677410943faa4c4d403f15f9639a8a15b4c19be9..upstream/master

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/c0eaf33b0522f211f9c28a7a1b0bd2a98ca7d50a
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-05T12:47:43+02:00

Fieldtype.ConvertToModelWithType (fabric8-services/fabric8-wit#2274)

# TL;DR

When changing the type of a work item we have to check if fields are compatible. This logic was deeply embedded in the work item repository but it can be outsourced and made available to other pieces of the code as well.

# About

`ConvertToModelWithType` tries to find way to convert the value `v` from the current `FieldType` to the other `FieldType` in model representation; returns `error` otherwise.

# Examples

* For example if the given value `v` is a `string` and the other `FieldType` is a string list, we will return the value `v` as an array of `interface{}` objects. 
* Let's say the current `FieldType` is a string list and the other `FieldType` is a single `string` field, then we check if the value `v` has only one element and return that instead of the whole list.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/4909a90aef93ad7efc600faa43e7f0037a04de54
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-06T13:17:10+02:00

Search by parent (fabric8-services/fabric8-wit#2275)

Allow to search for work items by `parent.id` and `parent.number`.

See https://openshift.io/openshiftio/Openshift_io/plan/detail/450.
See https://github.com/fabric8-services/fabric8-wit/issues/2244.


----