### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 4909a90aef93ad7efc600faa43e7f0037a04de54
+- hash: 164762f67a3a7634fa4ee1e8bb55c458281803c7
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
    --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit osio-pull.sh 4909a90aef93ad7efc600faa43e7f0037a04de54..upstream/master

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/1f5acd8548383c6445babef28152adbc9f4cf0c6
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-07T18:09:54+02:00

Make the board column tests cleanup after themselves (fabric8-services/fabric8-wit#2278)

Possibly related to openshiftio/openshift.io#4299

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/5f057eb1b858c2f54ad2f63610c08e1ebfd0c766
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-09-10T07:14:15+02:00

Provide endpoint to list spaces in which a user has a role (fabric8-services/fabric8-wit#2260)

* Provide endpoint to list spaces in which a user has a role

Added endpoint in `UserController`
Added tests in `user_blackbox_test.go` using go-vcr
to handle requests/responses with remote auth service.

fixes fabric8-services/fabric8-wit#2241
fixes fabric8-services/fabric8-auth#617
fixes openshiftio/openshift.io#3760

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/162bc651db650bff8d4c5c638ecdb447056be6fc
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-09-10T13:15:37+05:30

Use %q instead of "%s" (fabric8-services/fabric8-wit#2279)

This commit replaces all occurrences of \"%s\" with %q.
From the documentation of https://golang.org/pkg/fmt/

`%q	a double-quoted string safely escaped with Go syntax`


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/164762f67a3a7634fa4ee1e8bb55c458281803c7
**Author:** Baiju Muthukadan (baiju.m.mail@gmail.com)
**Date:** 2018-09-10T13:52:35+05:30

Search by label name (fabric8-services/fabric8-wit#2277)

Fixes work item no. 483

Syntax: `{"label.name":"somelabel"}`

----