### PR TITLE
Updating che-starter to the latest version

### DIFF
--- a/dsaas-services/che-starter.yaml
+++ b/dsaas-services/che-starter.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 70de15befd33c934ed74e47e2a33902a2a614648
+- hash: 59cd9ae35e8a1a1c056812efcea46e6253ab1505
   hash_length: 7
   name: che-starter
   path: /openshift-template/che-starter.app.yaml


### PR DESCRIPTION
Adding 'osio_spaceId' attribute during workspace creation that would be used by woopra and for OSD support
PR - https://github.com/redhat-developer/che-starter/pull/311