### PR TITLE
push fabric8-services/fabric8-wit@a661437 to prod

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 164762f67a3a7634fa4ee1e8bb55c458281803c7
+- hash: 59561d074d5bc6574994b4821db0bff0278fa010
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/

--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 59561d074d5bc6574994b4821db0bff0278fa010
+- hash: e75e0d152ee904a87e2bcb09b32f8777ba3ba0ab
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit git-log-pr.sh 164762f67a3a7634fa4ee1e8bb55c458281803c7..a661437b58e2a4f2e16b65872b16b4e8da944b0f

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/7ab24ac099a9316843c3044d1ad80dc4e0758934
**Author:** Tina Kurian (tkurian@redhat.com)
**Date:** 2018-09-10T09:47:29-04:00

area iteration root path should not be empty (fabric8-services/fabric8-wit#2214)

See https://github.com/fabric8-services/fabric8-wit/issues/2203

Co-authored-by: Konrad Kleine 193408+kwk@users.noreply.github.com

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/c2816aac486866afd666047d698bc9ffa2f54291
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-09-10T21:47:14+05:30

Update gopkg.lock file (fabric8-services/fabric8-wit#2282)

The `gopkg.lock` file is out of date. This PR updated it.


How to verify this PR
1. Run `dep ensure` on current master. You should see the `gopkg.lock` is modified.
2. Check the changes in `gopkg.lock` file against the ones in this PR. They should be same.
3. Run `dep ensure` again and you would notice `gopkg.lock` has not changed.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/426e11b8e8902a60b1cc5d9357e808b42403217b
**Author:** Elliott Baron (ebaron@redhat.com)
**Date:** 2018-09-10T16:29:27-04:00

Add authorization checking to Kubernetes package (fabric8-services/fabric8-wit#2207)

* Initial implementation of OpenShift authz checking

* Remove unused interactions in delete cassettes

* Add CanDeploy to filter deployable environments, maintain full list in kubeClient

* Implement authz check for DeleteDeployment

* Implement remaining methods, add tests for access control failure on builds

* Fix URLProvider changes, add tests for CanDeploy

* Better test error conditions

* Clean up code

* Add more internal environments to kubeclient tests

* Improve documentation, avoid boolean parameter for getting namespace

* Also check for wildcard rules

* Reduce size of go-vcr cassettes


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/a8fab53fcca1ae21cbccdbb6864dd5989777e3d8
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-11T08:37:08+02:00

testfixture.GetTestFileAndFunc() (fabric8-services/fabric8-wit#2149)

`GetTestFileAndFunc` returns the file and function of the first `_test.go` file to appear in the stack and returns it in this schema:

```
(see function github.com/fabric8-services/fabric8-wit/test/testfixture_test.TestGetGetTestFileAndFunc in test/testfixture/testfixture_test.go)
```

The result can be used to augment entities so that we always can tell which test created an entity that is a left-over and not cleaned up for example.

NOTE: The `testfixutre.GetTestFileAndFunc()` was taken out of this PR and already merge with this PR fabric8-services/fabric8-wit#2214. It is no longer part of this PR.

Most of the entities created with the `test/testfixture` package now contain a description that reveals in which function the entities was created. When there are left-over entities that hinder tests from running properly, you can now go in the database and find out which test produced these left-overs. To simplify things when running on CI, we now output a list of remaining spaces automatically that looks like this if everything went ok:

```
Check that no unexpected left-over spaces exist after running tests:

-[ RECORD 1 ]-------------------------------------

id          | 2e0698d8-753e-4cef-bb7c-f027634824a2

name        | system.space

description | Description of the space
```

Note, that the `system.space` is okay to appear in this list. It is expected even though it should go away at some point.

See https://github.com/fabric8-services/fabric8-wit/pull/2278 for an example of a PR that was easily fixed because of this PR. 

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/ba71ed19b86afb0cb6e39c2233d9a21504d958d1
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-11T12:14:39+02:00

Allow searching for work items with a single quote in the search string (fabric8-services/fabric8-wit#2272)

A query parameter `q` as in `https://prod-preview.openshift.io/api/search?q='problem` was not properly escaped before it was passed to the PostgreSQL `to_tsquery` function. We now remove the single quote from the input to `to_tsquery`.

On the frontend this API was called when search for work items in the "Links" section.

Addresses fabric8-services/fabric8-wit#2273 and https://github.com/openshiftio/openshift.io/issues/4288


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/d6a192dd906843ecff07c05a9922662a9014f700
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-11T12:50:30+02:00

Don't run tests involving the DB in parallel (fabric8-services/fabric8-wit#2276)

Possibly related to openshiftio/openshift.io#4299

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/f276f3affa3a0fc37a6a1648247acd767819c4a0
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-17T14:30:48+02:00

Don't have a zero-parent relationship for root iteration/area (fabric8-services/fabric8-wit#2283)

Before a root iteration/area had a parent iteration with a zeroed UUID:

```yaml
"relationships": {
      "parent": {
        "data": {
          "id": "00000000-0000-0000-0000-000000000000",
          "type": "iterations"
        },
```

That is removed now.

This adds a test that shows how a root and a child iteration/area are represented on JSONAPI level.

Added `testfixture.SetAreaNames()` and `testfixture.AreaByName()` functions as well.

This fixes the root cause for https://github.com/openshiftio/openshift.io/issues/4309 . The UI fix in https://github.com/Raunak1203/fabric8-planner/commit/e7c34a267613ae35c030041740f540abcde16849 only fixes a symptom by implementing a work around.


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/59561d074d5bc6574994b4821db0bff0278fa010
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-09-17T18:38:35+05:30

Better error logging for Delete action on /space endpoint (fabric8-services/fabric8-wit#2280)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/a917dfe49bfeaf5715f9822138b1599e94af00b9
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-20T23:24:41+02:00

Introduce number column for area and iteration and allow searching it (fabric8-services/fabric8-wit#2287)

This change refactors how a human readable number is assigned to work items. The refactored code makes it easy to have iterations and areas also have a human readable number.

See https://openshift.io/openshiftio/Openshift_io/plan/detail/618

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/71bed56c9f81cbc9981dadeb08bc7d4310cb11e5
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-21T08:48:55+02:00

Empty commit to trigger build (fabric8-services/fabric8-wit#2290)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/fce4430c17732ebb40f71b1cda63128d541cf645
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-21T09:38:26+02:00

Double the amount of allowed time for a pod to be ready (fabric8-services/fabric8-wit#2292)

See fabric8-services/fabric8-wit#2291

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/66831f397ae5f5ac24eac6d7a68180bf07d25293
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-21T18:05:23+02:00

Improve perf of calculating WIs in iteration (fabric8-services/fabric8-wit#2294)

We're seriously wasting time in calculating numbers of work items in
iterations by ignoring the fact that we're in a space. @pbergene gave
me a dump of slow queries this morning and while I was looking for
something completely else I noticed this piece:

```
 "Query Text": "SELECT iterations.id as IterationId, count(*) as Total,\
\    \    \    count( case fields->>'system.state' when 'closed' then '1' else null end ) as Closed FROM \\"work_items\\" left join iterations\
\    \    \    on fields@> concat('{\\"system.iteration\\": \\"', iterations.id, '\\"}')::jsonb WHERE (iterations.space_id = $1\
\    \    \    and work_items.deleted_at IS NULL) GROUP BY IterationId",
```

This query is so slow (~55 to 60ms) that and it appears so often that
the log of slow queries is cluttered with this.

This change is supposed to address this by limiting the number of work
items that are queried to the current space. Also the counting is
simplified by using PostgreSQLs `FILTER` expression (see
https://www.postgresql.org/docs/9.6/static/sql-expressions.html). We have
switched from a `LEFT JOIN` to an `INNER JOIN` for because we can
discard work items in the search result if they don't have an iteration
assigned (thanks to @jarifibrahim for measuring this here: https://github.com/fabric8-services/fabric8-wit/pull/2294#issuecomment-423544436).

No functionality should have been changed which is why all the test
should continue to work as expected.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/7fd5f0bfc27256b27a393d49f5f7c291770b5667
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-21T18:40:20+02:00

Remove the duration field kind (fabric8-services/fabric8-wit#2289)

We don't have any usage for the duration field kind. No space template uses this field type so far. The duration causes us far more problems than it does good. Especially in making the type system rock-solid, the duration has always caused problems. This is because we tried to store a duration as an `int64` which it really is (see https://godoc.org/time#Duration). The problem with this is that the underlying fields are stored in a JSONB structure. And JSON only supports `float64`. When we assigned an `int64` to `float64` the duration was rounded to the nearest `float64` and this is not accurate.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/fce0b6a058771dcd6907224ba20e974973f4c360
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-21T19:12:51+02:00

Double the amount of allowed time for a pod to be ready (fabric8-services/fabric8-wit#2295)

from 60 seconds to now 120 seconds

See fabric8-services/fabric8-wit#2291

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/07f931d323d4fe8a4cf6b03a60cceb1ee608393c
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-09-25T18:38:25+05:30

Improve DeleteSpace error messages (fabric8-services/fabric8-wit#2297)

Minor improvements to errors returned from the Detele action on space controller.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/cd7a01bc85da4d639239e143771bdab76a64c0b0
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-25T15:38:13+02:00

10x the amount of allowed time for a pod to be ready (fabric8-services/fabric8-wit#2298)

from 120 seconds to now 1200 seconds

See fabric8-services/fabric8-wit#2291

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/2a954824f5c699c6b4ce4bb21ebdc104025bbbb7
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-26T09:38:38+02:00

Use existing number sequences instead of looking them up again (fabric8-services/fabric8-wit#2299)

In order to avoid a sequential table scan on the `work_items` DB table we take the already calculated values for the new `number_sequences` table from the old `work_item_number_sequences`.

Before this was the query plan for `INSERT` into the new `number_sequences` table:

```
EXPLAIN
SELECT space_id, 'work_items' "table_name", MAX(number) 
FROM work_items 
WHERE number IS NOT NULL 
GROUP BY 1,2;
+--------------------------------------------------------------------------------+
| QUERY PLAN                                                                     |
|--------------------------------------------------------------------------------|
| GroupAggregate  (cost=37097.49..38835.71 rows=37629 width=52)                  |
|   Group Key: space_id, 'work_items'::text                                      |
|   ->  Sort  (cost=37097.49..37437.97 rows=136193 width=52)                     |
|         Sort Key: space_id                                                     |
|         ->  Seq Scan on work_items  (cost=0.00..20824.93 rows=136193 width=52) |
|               Filter: (number IS NOT NULL)                                     |
+--------------------------------------------------------------------------------+
```

and now it is:

```
EXPLAIN
SELECT space_id, 'work_items' "table_name", current_val 
FROM work_item_number_sequences
GROUP BY 1,2;
+--------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                     |
|--------------------------------------------------------------------------------------------------------------------------------|
| Group  (cost=0.29..3541.66 rows=43872 width=52)                                                                                |
|   Group Key: space_id, 'work_items'::text                                                                                      |
|   ->  Index Scan using work_item_number_sequences_pkey on work_item_number_sequences  (cost=0.29..3322.30 rows=43872 width=52) |
+--------------------------------------------------------------------------------------------------------------------------------+
```

Thanks go out to @jarifibrahim for bringing my attention to this sequential table scan.

See https://github.com/fabric8-services/fabric8-wit/issues/2291

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/cdef2aeb89120d9de594cbf257e17e8271a80c1f
**Author:** Elliott Baron (ebaron@redhat.com)
**Date:** 2018-09-26T14:43:12-04:00

Add deployments API to compute quota necessary for scale-up (fabric8-services/fabric8-wit#2286)

This PR adds a new API serviced by the deployments controller at /deployments/spaces/{spaceID}/applications/{appName}/deployments/{deployName}/podlimits.

Calling this API on a particular deployment determines the CPU and memory resources required in order to add a new pod to the deployment. This will allow the front-end to decide whether to stop the user from attempting to scale up a deployment if they do not have sufficient quota to do so successfully.

Example usage:
Request: GET https://openshift.io/api/deployments/spaces/$SPACE/applications/$APP/deployments/run/podlimits
Response: {"data":{"limits":{"cpucores":1,"memory":262144000}}}

This work was initially done by @chrislessard, and I have added tests and some modifications.

Fixes: openshiftio/openshift.io#3388

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/8ea84f1a182c1238ec28bfd7b8fa00b5cd0e76f5
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-28T10:29:51+02:00

Remove work item link category concept (fabric8-services/fabric8-wit#2301)

For over two years we haven't used the link category concept and it is not adding any value except for a theoretical one that can be realized differently directly by modifying a link type; hence I remove this concept.

This involves removal of

- category relationship in the link type's design  (package: `design`)
- category endpoints (packages: `design` and `controller`)
- repository for categories (package: `workitem/link`)
- removal of foreign key constraint on the `link_category_id` column of the `work_item_link_types` table

**NOTE:** the `work_item_link_categories` table or the `link_category_id` column on the `work_item_link_types` table will **NOT** be removed in the change. This is subject of a followup change. The reason is that we want old and new pods to run on the same database. (Thank you to @xcoulon for reminding me of that).

Also a lot of golden files were updated because the sequential part of UUIDs affected a shift in the UUID numbering.

This will fix https://github.com/openshiftio/openshift.io/issues/4299 the hard way :)

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/e483be8f1947aa05e52cd738ac9b8fd35c0e919f
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-09-28T12:18:06+02:00

acquire exclusive lock on spaces, areas, iterations and work_item_number_sequences table to avoid deadlock during migration (fabric8-services/fabric8-wit#2303)

In order to avoid the following deadlock situation, the 106 migration now acquires an exclusive lock on the `spaces`, `iterations`, `areas` and `work_item_number_sequences` tables.

Legend:
 - relation `36029` = `spaces`
 - relation `36042` = `iterations`

```
Process 875 waits for AccessExclusiveLock on relation 36029 of database 13322; blocked by process 5634.
Process 5634 waits for AccessShareLock on relation 36042 of database 13322; blocked by process 875.
```


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/b80e543668a36c223ef95cf866e85458323d4cd6
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-01T12:39:11+02:00

Have convert.EqualValue and convert.CascadeEqual (fabric8-services/fabric8-wit#2285)

## About

We need a way to compare if the object stored in the database is the same as the one we have loaded from a space template. In the template we don't care about when an object is created. That's why we need a method that is agnostic to the `gormsupport.Lifecycle` and a `Version` field.

In this change I've extended the `convert.Equaler` interface with a function called `EqualValue` that has the same signature as `Equal`. When implementing `EqualValue` one should focus only on values that make up the object to compare. For example, if an object has a `Version` and a `gormsupport.Lifecycle` member, those are good candidates to be ignored inside of `EqualValue`.

If an object has nested members that themselves implement the `convert.Equaler` interface, we want to call either `Equal` or `EqualValue` on them. It depends on what the outer, containing object is compared with. The `convert.CascadeEqual` takes care of that.

## Minor additional edits

Some implementation of `Equal` tested for the wrong object because they didn't isolate the data properly using subtests. I've fixed that. Also, some implementations of `Equal` didn't test for `Version` or `Lifecycle` differences.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/54f03e1dbc9ed28e73a2f56570db7869b58616ea
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-01T13:19:30+02:00

empty commit to trigger build (fabric8-services/fabric8-wit#2308)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/8e81220909349e2fbb2b2411b85735b5608296fb
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-01T14:47:15+02:00

Revert "Introduce number column for area and iteration and allow seahching it (fabric8-services/fabric8-wit#2287)" (fabric8-services/fabric8-wit#2307)

This reverts commit a917dfe49bfeaf5715f9822138b1599e94af00b9 (aka fabric8-services/fabric8-wit#2287).

We're experiencing trouble to migrate the DB for this change (see https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/2349). Currently the prod-preview database is not being updated and stalls at the migration from 105 to 106 (number for iteration an area).

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/af5e62d7dcf2366ac4f387407f8b41bafe495e7e
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-01T17:10:20+02:00

Add number_sequences table and nullable 'number' column on areas and iterations tables (fabric8-services/fabric8-wit#2309)

This adds back the `number_sequences` table the `number` columns on the `areas` and `iterations` tables (known from fabric8-services/fabric8-wit#2287 but then reverted). But it does this in three individual steps. This change is backwards compatible with the old code as the `number` column is nullable. Except for this structural change, no data is changed.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/c824993728eff6a632a241cbb82360dd2d103d37
**Author:** Elliott Baron (ebaron@redhat.com)
**Date:** 2018-10-01T16:43:57-04:00

Add API to show resource usage for the current space (fabric8-services/fabric8-wit#2306)

This PR adds a deployments-related API under /deployments/environments/spaces/:spaceID. This endpoint returns resource usage for each of the user's environments, divided into usage by the specified space and usage by all other spaces combined. Currently this only returns CPU and memory usage, and not objects such as pods or secrets.

There is an older /deployments/spaces/:spaceID/environments endpoint which has been left for backwards compatibility until the front-end is switched over completely.

Example usage:
Request: GET https://openshift.io/api/deployments/environments/spaces/$SPACE_ID
Response:

{
  "data": [
    {
      "attributes": {
        "name": "run",
        "other_usage": {
          "cpucores": {
            "quota": 2,
            "used": 0.488
          },
          "memory": {
            "quota": 1073741824,
            "used": 262144000
          },
          "persistent_volume_claims": {
            "quota": 1,
            "used": 0
          },
          "replication_controllers": {
            "quota": 20,
            "used": 6
          },
          "secrets": {
            "quota": 20,
            "used": 9
          },
          "services": {
            "quota": 5,
            "used": 3
          }
        },
        "space_usage": {
          "cpucores": 1.488,
          "memory": 799014912
        }
      },
      "id": "run",
      "type": "environment"
    }
  ]
}

This work was started by @chrislessard, which I have put the finishing touches on and opened the PR on his behalf.

Fixes: openshiftio/openshift.io#3129

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/e75e0d152ee904a87e2bcb09b32f8777ba3ba0ab
**Author:** Baiju Muthukadan (baiju.m.mail@gmail.com)
**Date:** 2018-10-03T17:25:48+05:30

Query language support for child iteration & area (fabric8-services/fabric8-wit#2182)

Query language support to fetch work items that belong to an iteration and its child iterations. Similarly, areas can be used.

Example:-

```
{"iteration": "name", "child": true}
```

The default is true.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/8795c9f883ba2a4f9092041193701320abf4b761
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-10-08T19:16:45+05:30

Add more logs for Delete action on space controller (fabric8-services/fabric8-wit#2310)

This PR adds more logs to the delete action on space controller.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/a661437b58e2a4f2e16b65872b16b4e8da944b0f
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-10-09T12:48:37+05:30

Enum.ConvertFromModel should use Basetype.ConvertFromModel method (fabric8-services/fabric8-wit#2224)

The `ConvertFromModel` method on `Enum Type` now uses `ConvertFromModel` method of the `base type` instead of `ConvertToModel`.


----

