### PR TITLE
Update fabric8-tenant-jenkins version 4.0.108

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 30e353513ff4e9e1f9ea443fcff88efb263c768e
+- hash: a99b73223a320659f543571c6edfb59e8b5e7802
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
This PR will upgrade the fabric8-tenant-jenkins
version to 4.0.107 which have the fix for following

Issue https://github.com/fabric8io/osio-pipeline/issues/31
PR https://github.com/fabric8-services/fabric8-tenant-jenkins/pull/134