### PR TITLE
Update fabric8-tenant

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ed5745711ad14a07a0d896db48d30a10139aa64e
+- hash: bdb29d045f10c251a571c9955f8ee0d3f23ea205
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
Update fabric8-tenant to promote:

* fabric-tenant-che template to version 2.0.90
* refactoring changes of components that communicate with auth service
* integration with Sentry