### PR TITLE
Used latest version of plugin registry

### DIFF
--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 76cb9978e271e982246ce1c4d70c5dd6a7d89c11
+- hash: 7d9b7aae961fb76642a8ea3e5e9c60d34604f9dd
   hash_length: 7
   name: che-plugin-registry
   path: /openshift/che-plugin-registry.yml


### PR DESCRIPTION
* 7d9b7aa 2018-10-01 | Setup jupyter editor (https://github.com/eclipse/che-plugin-registry/issues/39) (HEAD -> master, origin/master) [Sergii Kabashniuk]
* af5cc5e 2018-10-01 | Change Theia URL to point to the latest release [Oleksandr Garagatyi]
* 9cd9400 2018-09-26 | Update Theia URL to get HOSTED_PLUGIN_HOSTNAME env variable fix [Mario Loriedo]
* 7fb4ca5 2018-09-25 | Update org.eclipse.che.editor.theia/1.0.0 URL [Mario Loriedo]