### PR TITLE
Update `auth` to 0f9921

### DIFF
--- a/dsaas-services/auth.yaml
+++ b/dsaas-services/auth.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 51dd80d5a116ed9505cce7256a5ec705fca5c76a
+- hash: 0f9921980549b2baeb43f6f16cbe794f430f498c
   name: fabric8-auth
   path: /openshift/auth.app.yaml
   url: https://github.com/fabric8-services/fabric8-auth/


### PR DESCRIPTION
# Changes

**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/d546608eb57ef7a6dfb27ad6e500f8dd212eaef6
**Author:** Shane Bryzak (sbryzak@gmail.com)
**Date:** 2018-09-19T05:06:50+10:00

RPT: Trigger privilege cache renewal into relevant workflows (fabric8-services/fabric8-auth#637)

fixes fabric8-services/fabric8-auth#612

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/c3cc3295215081efcc683a2a81452223131d26ff
**Author:** Shoubhik Bose (sbose78@gmail.com)
**Date:** 2018-09-26T11:49:12+05:30

Separate out userinfo lookup from login (fabric8-services/fabric8-auth#618)

* separate out userinfo lookup from login

* refactor new configuration method name

* fix json attr

* add id from userapi response

* update interface def to use LoginOAuthIDP

* use interface

* fix tests

* new login flow

* fix up more tests

* add token-identity verification

* add tests for oauth2

* remove methods

* dont talk to keycloak while creating a new user

* fix test after pull

* chore: fix typos and clean code

* fix: rename variable by adding prefix oauth to endpoint.userinfo

* docs: correct doc comment for GetOAuthEndpointToken

* fix: rename LoginIdentityProvider to IdentityProvider as it's in login package

* fix: cleanup code

* fix tests, add first login functionality

* add tests for filluser..

* test to see if WIT is being called

* validate err


----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/bcb557116acd6ff2e3cdc0e90f988b492679ef92
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-09-26T09:18:16+02:00

Avoid duplicate scopes in cached privileges (fabric8-services/fabric8-auth#663)

list scopes using the `DISTINCT` SQL option to avoid duplicates
added tests

also, fixed a few errors reported when building with go 1.11

fixes fabric8-services/fabric8-auth#661

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>



----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/17ecc1d3f027cafd0660e8d5a10791107c069183
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-09-26T14:27:41+02:00

Fix govet errors (fabric8-services/fabric8-auth#665)

* Fix govet errors

fix govet errors, and disable `vet` during tests
to avoid failures on the `app/test` pkg

fixes fabric8-services/fabric8-auth#664

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/5f59853d607afa6c29b2159324541388885c489e
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-09-26T20:18:24+02:00

Missing `session_state` in generated token (fabric8-services/fabric8-auth#667) (fabric8-services/fabric8-auth#668)

Fill the `session_state` claim of the generated access token
with a random UUID

Fixes fabric8-services/fabric8-auth#667

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/7ab68d7f1a29954223939c91e045daaf6db82eac
**Author:** Dipak Pawar (dipakpawar231@gmail.com)
**Date:** 2018-09-28T17:45:03+05:30

feat(fabric8-services/fabric8-auth#578): implement refresh token workflow in auth (fabric8-services/fabric8-auth#666)



----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/ef65c8f2b39faf12264fb1d3aa25d0fd5812fed1
**Author:** Shoubhik Bose (sbose78@gmail.com)
**Date:** 2018-10-01T07:24:51-05:00

Allow +preview@redhat.com approvals (fabric8-services/fabric8-auth#675)

fixes fabric8-services/fabric8-auth#672

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/0bbb377bc3f0b5afe9cfb18a131be870ab671327
**Author:** Dipak Pawar (dipakpawar231@gmail.com)
**Date:** 2018-10-01T18:40:41+05:30

Create token for dev user in developer mode (fabric8-services/fabric8-auth#676)

fixes fabric8-services/fabric8-auth#674

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/2010dabb533914a59bdae0888c6ae22d0de93d31
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-10-01T16:01:39+02:00

Modify refresh workflow for RPTokens (fabric8-services/fabric8-auth#670)

* Modify refresh workflow for RPTokens

If the user request contains a RPToken, then
this latter is used to generate a new RPToken
(while checking that the permissions still apply),
otherwise, a "simple" access token is returned.

also:
- refactor test: rename testsuite, using subtests for the refresh token endpoint test
- use minimock istead of Dummy implementation

Fixes fabric8-services/fabric8-auth#613

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/53be0d060dcfd837d6a91322730cc1b959d0b481
**Author:** Alexey Kazakov (alkazako@redhat.com)
**Date:** 2018-10-02T05:32:01+05:30

Proxy /api/clusters to Cluster Management Service (fabric8-services/fabric8-auth#659)

* Proxy /cluster to Cluster Management Service

* Call Cluster Managment Service to get cluster info

* Fix test compilation errors

* Remove unused function

* Fix tests

* Fix conflicts after merge to master

* More tests

* cleanup

* Fix merge conflicts

* Lazy cluster service initialization

* More tests

* Add synchronization to Default Token Manager initialization

* More tests

* Addressing PR review comments

* Return a copy of cluster instead of pointer to original cached object

* Add comments about avoiding Auth-Cluster cycle dependencies during startup

* Add some logs

* Fix cluster/auth path


----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/fdb2732a44a72d1428d84a7c77eef2f07193a408
**Author:** Alexey Kazakov (alkazako@redhat.com)
**Date:** 2018-10-02T06:26:00+05:30

Fix default cluster service URL (fabric8-services/fabric8-auth#677)



----


**Commit:** https://github.com/fabric8-services/fabric8-auth/commit/952a29d9a35639918f8ecdc06349da0a0cf527b3
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2018-10-03T11:53:33+02:00

Fix compilation errors on becnh tests (fabric8-services/fabric8-auth#682)

fixes fabric8-services/fabric8-auth#681

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----