### PR TITLE
Revert "push fabric8-services/fabric8-wit@a661437 to prod"

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e75e0d152ee904a87e2bcb09b32f8777ba3ba0ab
+- hash: 164762f67a3a7634fa4ee1e8bb55c458281803c7
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
Reverts openshiftio/saas-openshiftio#1065 because the deployment failed with a DB migration error:

**core-131-7dvb8.log:** (see [here for archived Kibana log](https://logs.dsaas.openshift.com/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1w,mode:relative,to:now))&_a=(columns:!(kubernetes.container_name,message),index:'project.dsaas-production.129c1244-1b37-11e7-8db9-124160897002.*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'kubernetes.pod_name:%22core-131-jtvqg%22+AND+kubernetes.namespace_name:%22dsaas-production%22')),sort:!('@timestamp',desc))))

```
pmcd: cannot open log "/dev/force-logging-to-stderr" for writing : Permission denied
Log for pmcd on core-131-7dvb8 started Tue Oct  9 08:43:18 2018


active agent dom   pid  in out ver protocol parameters
============ === ===== === === === ======== ==========
pmcd           2                 2 dso i:6  lib=/var/lib/pcp/pmdas/pmcd/pmda_pmcd.so entry=pmcd_init [0x7f6bd9630500]
proc           3                 2 dso i:7  lib=/var/lib/pcp/pmdas/proc/pmda_proc.so entry=proc_init [0x7f6bd940f620]
linux         60                 2 dso i:7  lib=/var/lib/pcp/pmdas/linux/pmda_linux.so entry=linux_init [0x7f6bd91dbd90]
prometheus   144   121  13  14   2 bin pipe cmd=python /var/lib/pcp/pmdas/prometheus/pmdaprometheus.python

Host access list empty: host-based access control turned off
User access list empty: user-based access control turned off
Group access list empty: group-based access control turned off


pmcd: PID = 7, PDU version = 2
pmcd request port(s):
  sts fd   port  family address
  === ==== ===== ====== =======
  ok     5       unix   /var/run/pcp/pmcd.socket
  ok     3 44321 inet   INADDR_ANY
  ok     4 44321 ipv6   INADDR_ANY
[Tue Oct  9 08:43:18] pmcd(7) Info: PMNS file "DEFAULT" is unchanged
time="2018-10-09T08:43:23Z" level=warning msg="unable to parse log level configuration error: \"not a valid logrus Level: \\\"\\\"\"" 
{"err":"user: unknown userid 1000070000","file":"/tmp/go/src/github.com/fabric8-services/fabric8-wit/main.go","func":"main.printUserInfo","level":"warning","msg":"failed to get current user","pkg":"main","time":"2018-10-09 08:43:23"}
{"level":"info","msg":"Configured connection pool max idle 90","time":"2018-10-09 08:43:23"}
{"level":"info","msg":"Configured connection pool max open 90","time":"2018-10-09 08:43:23"}
{"current_version":104,"level":"info","msg":"Attempt to update DB to version 105","next_version":105,"pkg":"migration","time":"2018-10-09 08:43:23"}
{"err":"pq: duplicate key value violates unique constraint \"iterations_name_space_id_path_unique\"","file":"/tmp/go/src/github.com/fabric8-services/fabric8-wit/migration/migration.go","func":"github.com/fabric8-services/fabric8-wit/migration.ExecuteSQLFile.func1","level":"error","line":525,"msg":"failed to execute this query in file: 105-update-root-area-and-iteration-path-field.sql \n\n-- append ID to non-root iteration and area paths\nUPDATE iterations SET path=text2ltree(concat(path, concat('.',replace(cast(id as text), '-', '_')))) WHERE path!='' AND path IS NOT NULL;\nUPDATE areas SET path=text2ltree(concat(path, concat('.',replace(cast(id as text), '-', '_')))) WHERE path!='' AND path IS NOT NULL;\n\n-- update root iteration and area paths to use converted ids\nUPDATE iterations SET path=text2ltree(replace(cast(id as text), '-', '_')) WHERE path='' OR PATH IS NULL;\nUPDATE areas SET path=text2ltree(replace(cast(id as text), '-', '_')) WHERE path='' OR PATH IS NULL;\n\n-- alter iteration and area path column to not accept NULL values\nALTER TABLE iterations ALTER COLUMN path SET NOT NULL;\nALTER TABLE areas ALTER COLUMN path SET NOT NULL;\n\n-- drop constraints\nALTER TABLE iterations DROP CONSTRAINT iterations_name_space_id_path_unique;\nALTER TABLE areas DROP CONSTRAINT areas_name_space_id_path_unique;\n\nALTER TABLE iterations ADD CONSTRAINT non_empty_path_check CHECK (trim(path::text) \u003c\u003e '');\nALTER TABLE areas ADD CONSTRAINT non_empty_path_check CHECK (trim(path::text) \u003c\u003e '');\n\n-- add constraints for subpaths - two areas/iterations under the same parent area/iteraion must have a unique name\nCREATE UNIQUE INDEX areas_name_space_id_path_unique ON areas (\n    space_id, \n    coalesce(lca(path, path), ''), \n    name\n) WHERE deleted_at IS NULL;\n\nCREATE UNIQUE INDEX iterations_name_space_id_path_unique ON iterations (\n    space_id, \n    coalesce(lca(path, path), ''),\n    name\n) WHERE deleted_at IS NULL;\n\n\n","pid":1,"pkg":"migration.ExecuteSQLFile","req_id":"","time":"2018-10-09 08:43:23"}
Failed to obtain reader, Failed to marshal fields to JSON, json: unsupported type: migration.fn
{"err":"failed to execute migration of step 0 of version 105: pq: duplicate key value violates unique constraint \"iterations_name_space_id_path_unique\"\n","level":"panic","msg":"failed migration","pid":1,"time":"2018-10-09 08:43:23"}
panic: (*logrus.Entry) (0x1ae5560,0xc420494780)

goroutine 1 [running]:
github.com/fabric8-services/fabric8-wit/vendor/github.com/sirupsen/logrus.Entry.log(0xc42007c500, 0xc420771800, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/go/src/github.com/fabric8-services/fabric8-wit/vendor/github.com/sirupsen/logrus/entry.go:124 +0x5eb
github.com/fabric8-services/fabric8-wit/vendor/github.com/sirupsen/logrus.(*Entry).Panic(0xc420494730, 0xc42094f878, 0x1, 0x1)
	/tmp/go/src/github.com/fabric8-services/fabric8-wit/vendor/github.com/sirupsen/logrus/entry.go:169 +0xa8
github.com/fabric8-services/fabric8-wit/vendor/github.com/sirupsen/logrus.(*Entry).Panicln(0xc420494730, 0xc42094f900, 0x1, 0x1)
	/tmp/go/src/github.com/fabric8-services/fabric8-wit/vendor/github.com/sirupsen/logrus/entry.go:264 +0xe0
github.com/fabric8-services/fabric8-wit/log.Panic(0x0, 0x0, 0xc420771770, 0x1b60c33, 0x10, 0x0, 0x0, 0x0)
	/tmp/go/src/github.com/fabric8-services/fabric8-wit/log/log.go:218 +0x23c
main.main()
	/tmp/go/src/github.com/fabric8-services/fabric8-wit/main.go:136 +0x45e9

```

Apparently this migration does not work:

```sql
CREATE UNIQUE INDEX iterations_name_space_id_path_unique ON iterations (
    space_id, 
    coalesce(lca(path, path), ''),
    name
) WHERE deleted_at IS NULL;
```

It was introduced in this PR: https://github.com/fabric8-services/fabric8-wit/pull/2214 here:

https://github.com/fabric8-services/fabric8-wit/pull/2214/files#diff-378c290c58f9a723118a29ecc0d0b4a5R27



