### PR TITLE
Update fabric8-tenant df67bf

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: bdb29d045f10c251a571c9955f8ee0d3f23ea205
+- hash: df67bff66a1c7e9875f36731176372946ba562ed
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
**Commit:** https://github.com/fabric8-services/fabric8-tenant/commit/df67bff66a1c7e9875f36731176372946ba562ed
**Author:** Aslak Knutsen (aslak@4fs.no)
**Date:** 2018-10-09T15:53:24+02:00

Sort Role before RoleBindingX (fabric8-services/fabric8-tenant#656)

Role should exist before we attempt to bind to it.



----


**Commit:** https://github.com/fabric8-services/fabric8-tenant/commit/bc5dbfa37ac2e7d6dc2b209e59cb272ec3159f81
**Author:** Matous Jobanek (matousjobanek@gmail.com)
**Date:** 2018-10-05T09:49:21+02:00

feat: use sha of latest commit that changes a template file as its version (fabric8-services/fabric8-tenant#648)



----


**Commit:** https://github.com/fabric8-services/fabric8-tenant/commit/7537946a69a222340a7d6f0a9527468cfa995bea
**Author:** Matous Jobanek (matousjobanek@gmail.com)
**Date:** 2018-10-04T12:36:23+02:00

fix: initialize map before assigning to an entry in it (fabric8-services/fabric8-tenant#650)



----


**Commit:** https://github.com/fabric8-services/fabric8-tenant/commit/eb5a8a47fc29fdb0dd7e2ba434e8ed0d7937b067
**Author:** Matous Jobanek (matousjobanek@gmail.com)
**Date:** 2018-10-04T10:39:09+02:00

feat: simplify template management (fabric8-services/fabric8-tenant#634)

The location of the templates is changed from the external projects f8-tenant-[che|jenkins|team] to the directory environment/templates/ inside of this fabric8-tenant project. The files (templates) located in the directory and their names correspond to namespaces they are used for. All objects (contained in the templates) have been moved from the original ones (downloaded from Maven central) just with small cosmetic changes - the result and the number of the objects are same.

----
