### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1371e8243fb9f68775a50a8eca738193db706164
+- hash: 87bf305c5d73a9cf4df5f37172aaf19d9e7034ea
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit git-log-pr.sh 1371e8243fb9f68775a50a8eca738193db706164..87bf305c5d73a9cf4df5f37172aaf19d9e7034ea

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/87bf305c5d73a9cf4df5f37172aaf19d9e7034ea
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-10T13:12:53+02:00

Update 105-update-root-area-and-iteration-path-field.sql (fabric8-services/fabric8-wit#2313)

Based on [this discussion](https://chat.openshift.io/developers/pl/6m4cojtiotdoueqot8uww5ybpe) we first remove the unique name index on the `iterations` and `areas` table before we modify the data.

In a previous attempt (https://github.com/fabric8-services/fabric8-wit/pull/2312) I haven't moved the removal of the index enough up.

This should fix the migration issue that was visible here: https://github.com/openshiftio/saas-openshiftio/pull/1082

----