### PR TITLE
Update idler

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: c9310811e92f3ffb3c0c3a48a168977c5d1de0e7
+- hash: 8840ca97afdd2c15369d1d4d1432622ddc258ce2
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
This version of idler adds more logging so that we get some insights
into the cause for idler refusing to idle or un-idle jenkins.
The logs may also help with debugging the idler-unidle loop which we see
after change to tenants.