### PR TITLE
Update fabric8-tenant

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: df67bff66a1c7e9875f36731176372946ba562ed
+- hash: 06c5c631e14013a91969920b87a832d9ef20e91c
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
This deploy includes changes to:
  - Not autostart Jenkins on changes to DC (#663)
  - fix(#655): use raw.githubusercontent.com host for downloading template files