### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: b7a63ec50eeff79e3ffc31322f038edb67c0b583
+- hash: f65e037c2c00668c410342b250c63485ad8b52dd
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* f65e037c2 style(lint): add airbnb rule overrides
* 915a75bc4 feat(angular): add angular support to scripts
* ac48d5b9f fix(header): fix capitalization of 'Create Space' in the user dropdown (#3377)
* 595e82fd4 Deployments utilization bar component can display "other spaces" utilization (#3343)
* feff1cc17 feat(scripts): add script to launch production server using http-server
* f26f5a98e fix(header): remove duplicate of spaces (#3374)
* d2b9d254a chore(lint): fix lint errors
* ec70ecd0c feat(lint): add htmlhint and angular language service support
* 4dc8160dc fix(space-dashboard): fix work-item filter query in create work-item widget (#3365)
* e93608dbf fix(codebases): fix switch component change state trigger after upgrade (#3368)
* 35ec3b9ff fix(version): Planner version upgraded to 0.56.0 (#3373)
* 5983eb0ad feat(widgets): initial setup for react widgets package
* d674abd15 fix(scripts): expose webpack configs for reuse
* 964a8b91a style(style-lint): add .md files to ignore list
* 52b949e86 style(style-lint): allow hex colors
* 3428124f5 fix(less): fix pfng list header text spacing (#3369)
* 14e010c6f feat(header): add 'Create Issue' help menu item to open GitHub issues (#3367)
* fd4f24c65 fix(stack-report-btn): fixes stack report button not appearing in pipelines view wrt recent change in stage name (#3366)
* 1d8b9c80b fix(header): fix header navbar colouring to be dark (#3364)
* b1310ad02 fix(test): skip intermittent failing test
* 04c4bd681 fix(scripts): rewire react-scripts instead of managing our own copy
* 34cde6442 fix(lint): remove promise lint rule which conflicts with typescript no unused local vars warning
* 09cf75eaf fix(lint): add common eslintrc for packages
* ad5bc32c4 feat(monorepo): initial monorepo setup (#3357)
* dc27273f7 fix(home): bring back feature flagged old dashboard (#3362)
* 6968bc976 fix(home): remove onboarding area from home page (#3361)
* a8c20a484 fix(codebases): change font weight for codebase title (#3360)
* 06bd8fbf1 fix(header): move chat with us to help section (#3359)
* 2099b3c9b clean(test): remove unused and document running unit test (#3358)
* cd786a085 fix(ngx-login-client): upgrade ngx-login-client and provide value for WIT_API_PROXY (#3354)
* 1750c3598 fix(tree-view): Fix missing expand toggle in area components (#3356)
* c73b0481b fix(tenant): modify _tenant page to reflect changes coming in fabric8-services/fabric8-tenant#634 (#3344)
* 67a5c9aba fix(package): update launcher to 2.0.8 (#3355)
* a82d70152 fix(build): switch to 'eval-source-map' for dev as it is faster on reload then 'source-map' (#3353)
* 67048fbff fix(webpack): remove sourcemap file mappings to improve locating sources in dev web inspector (#3352)
* 36787821d feat(package): update recommender to 1.0.2 (#3351)
* b02926956 fix(deployments): cache pod quota requirements (#3350)
* 57be60aa4 fix(css): omit css sourceMap in prod and extract css to separate file (#3348)
* b03be5771 fix(build): set up the build to release now that the version of semantic-release has been updated
* 7b0a564ea style(deployments): code cleanup (#3329)
* 23dc8dd47 style(settings): code cleanup (#3330)
* f3ca84ad8 feat(deployments): allow scaling only if remaining quota is sufficient (#3336)
* b22f17333 cleanup(imports): remove unused imports (#3345)
* 2087e185a refactor(overview-component): general code cleanup (#3328)
* 7f70afa85 feat(settings): show openshift cluster url in connected account section (#3332)
* 89d11a4cd cleanup(email-verification): remove unused component for email verification (#3337)
* fe17a17f4 fix(jest): add --runInBand for jest:debug (#3346)
* e45d1ce22 fix(angular): set preserveWhitespaces to true for compatibility
* 27776b77d fix(build): update build to run test script
* 093cb7870 fix(script): move the script to call jest for tests
* 35fe854e4 fix(test): skip 2 tests that fail randomly
* 8ab4eb415 fix(rxjs): add missing pipe
* 1e5b74d31 fix(rxjs): more upgrade to rxjs updates
* e573c5f36 fix(context): remove dup line from merge
* 22d9fa648 support Jest (#3342)
* b3b1b4065 fix(build): clean up tsconfig
* 9217e4b95 fix(test): skip 40 tests to get the webpack test to build
* 0a519b17a fix(test): turn on tsconfig sourcemaps to work with istanbul-instrumenter-loader
* 4be6a8bfe fix(imports): clean up imports
* 8886f6982 fix(test): comment out the .html raw-loader as it was causing the tests to not run
* c5a0d70c1 fix(test): turn off lint to save time, update changes in webpack
* cf33cbece fix(build): update webpack config to allign with latest webpack
* 456d04d2e fix(test): due to a change in angular 6, we need to set preserveWhitespaces to true
* e7b1b236d fix(test): remove whitespace that broke tests on a src ref
* 2267f07fd fix(test): add reference to test support files in webpack config
* d4e7595b3 fix(test): comment out sourcemaps to get past 'FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory'
* 195b71199 feat(package): upgarde Typescript to 3.0.3
* 08447e873 fix(test): uncomment the entry points in the test webpack config
* 30deb6750 clean(test): remove unusued func tests, moved to https://github.com/fabric8io/fabric8-test/ (#3335)
* 3a7cf4e60 fix(test-build): turn off sourcemaps in tsconfig and remove entry in webpack config to get the tests to run
* 3b28f5947 fix(build): clean up webpack configs, trying to get the tests to work
* 501947405 fix(package): downgrade TypeScript to 2.9.2 to work with Angular
* 0b6290e8d fix(package): downgrade rxjs to 5.2.2 to work with components not upgraded yet
* ddb168a10 fix(build): remove MiniCssExtractPlugin ref in build
* 5ec7a03e5 fix(rxjs-compat): downgrade to 6.2.2 https://github.com/ReactiveX/rxjs/issues/4070 (#3333)
* 68c5f7c77 fix(perf): update the npm scripts to call perf correctly
* c80fd5e7c feat(build): set perf build to rely on prod
* 2e0c6efa2 fix(webpack): add ManifestPlugin
* e50752cd1 fix(webpack): fix errors with uglify in prod webpack config
* 1f5c1e78a fix(package): update the package-lock
* 0c0f27b4c feat(package): upgrade webpack to 4.19.1
* b99d79ad4 feat(package): upgrade ts-loader to 5.1.1
* a8622925a feat(package): upgrade semantic-release to 15.9.16
* 82bf44f09 feat(package): upgrade patternfly to 3.54.8
* 51482f0bd feat(package): upgrade gh-pages to 2.0.0
* 650536000 feat(package): upgrade @types/webpack to 4.4.12
* 7d78d663e feat(package): upgrade @types/node to 10.10.1
* d5a3d4038 feat(package): upgrade @ngtools/webpack 6.2.3
* 748a68069 feat(package): upgrade @angular to 6.1.8
* 685e051ea feat(package): update ngx-fabric8-wit to 8.1.1
* e3e81bd6f feat(rxjs): import rxjs-compat globally
* 02bccc047 fix(build): remove ref to non-existant type 'source-map' in the 'types' section
* 29b6fecc4 fix(version): downgrade ngrx (5.2.0) back to compatible version for planner
* 7b8567d77 fix(oauth): import oauth module instead of service
* f6428a17d fix(http): remove unused http import and injection
* b947ffdcd feat(build): change webpack to not use extractCSS and prep for using MiniCssExtractPlugin
* c77b046fe feat(auth): add the auth interceptor
* d5cb990c7 fix(version): upversion ngx-fabric8-wit and use new API
* ed2c34f3a fix(webpack): fix errors with loading css due to extract text plugin (#3326)
* 427f910da fix(package): put back @types/source-map 0.5.7 to fix a source-map issue with rxjs
* 4c8d96ff5 fix(webpack): change webpack chunking and optimizations so that  main bundle is included in html template
* 225569c8b fix(package): downgrade angular-tree-component to ^7.0.0 to match patternfly
* 433e9d567 fix(webpack): source-map-loader warnings on rxjs compat (#3325)
* ff7eaab27 fix(auth): clean up import of angular-oauth2-oidc
* 5aaadeabe fix(package): downgrade bootstrap to work with patternfly
* 149ef2413 fix(rxjs): upgrade use of observableNever in space service spec
* e96f4b457 fix(profile): remove test of error that doesn't catch error (and doesn't compile)
* 1add86e7e fix(auth): update lib ref for angular-oauth2-oidc
* 8e86721df feat(build): update the test configs in trying to get the unit tests to run
* a49b141b5 feat(package): upgrade Typescript to 3.0.3 to get the ts-loader to work, this might break angular
* d1fec3210 fix(lint): fix lint errors with imports
* 5afd4a93e fix(build:dev): remove awesone-typescript plugin and unsued UgliflyPlugin for dev build
* 02c85241a fix(rxjs): Upgrade Scheduler import, fix Type information
* 9a46d82dd clean(formatting): tslint for import statement
* e8b465479 fix(TS2339): TS error on connect needed cast as ConnetableObservable
* 36466cfca fix(rxjs): change the ref to observable 'empty' so that it could be called
* 536c98476 fixup fix(treelist): point the treelist to patternfly-sandbox-ng so we can keep using it for now
* eca819044 feat(package): add patternfly-sandbox-ng
* 3d80d9b17 feat(lint): fix lint errors and upgrade rxjs syntax
* c5c8f5772 feat(http): remove old fabric8-ui-http.service
* b3d637958 feat(package): update libs
* f8bd623ac feat(http): remove refrence to login-client HttpService
* 5ed3bb4fc feat(build): remove gendir, instead look at using skipTemplateCodeGen
* 5aa429ac3 feat(http): update app.module to use ng6 httpClient
* 57482af47 feat(injectionToken): replace OpaqueToken with InjectionToken
* 3a6860968 feat(build): remove old webpack plugins and replace with 'optimization' config
* 257f8ba1a feat(build): add wepback mode to configs
* a67fbeae1 feat(package): update lock file
* 335dc2a76 feat(package): update webpack to 4.18.0
* 1a96289a3 feat(package): update angular-oauth2-oidc to 4.0.3
* 1bfafa700 feat(package): update lib versions
* 4029406ba fix(package): update package-lock
* 2dcd37002 feat(build): update test build/configs for webpack 4
* 07f937ddc fix(build): alphebetize the tsconfigs
* a0cbe4942 feat(lint): add RxJS lint rules
* 6adceca5d feat(package): set yargs to 12.0.1
* 63226e529 feat(package): remove angular2-tree-component@3.1.0. The new version is angular-tree-component.
* 41ee895af feat(package): remove angular2-oauth2@1.3.10. The new version of this lib is called angular-oauth2-oidc.
* 1b4fa7703 fix(package): @types/source-map@0.5.7 is a stub types definition for source-map and isn't needed
* 7a1592683 feat(package): update @angular to 6.1.6
* 07c34d54c fix(license): add a file ext to the LICENSE
* 81cd83a6a (tag: v1.121.0, matousjobanek/master) feat(recent): introduce recent-utils to be extended by context and spaces service for "recent" logic (#3341)