### PR TITLE
Update idler - fixes ignoring dc events

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0292a87c27918b8010abd1586abf04bc93f6febf
+- hash: f2054459a5209d04723fc3b2b3f022acad0b4228
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
This update includes the following changes
  -  Improvements to Idle/UnIdle condition evaluation
  -  Add more logging to openshift-client
  -  Reverts "Remove DC and user condition (#285)"
  -  Reverts "Remove unused WatchDeployment in openshift client"