### PR TITLE
Revert "Update idler - fixes ignoring dc events"

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: f2054459a5209d04723fc3b2b3f022acad0b4228
+- hash: 0292a87c27918b8010abd1586abf04bc93f6febf
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
This reverts commit 704d9d818bb8c01371a18568771b94b1d606ea26.
The deployment is causing an OOM and the idler pod gets killed, hence
reverting the patch until we have a fix.