### PR TITLE
Update idler

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0292a87c27918b8010abd1586abf04bc93f6febf
+- hash: fbe11259813242911a7f8b50770425b2ebb66b9a
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
This patch fixed the idler issue that aggressively idles jenkins soon
after a build

Changes include:
  - Increase memory and cpu limits for idler
  - More log message to indicate user-idler and go-routine count
  - Revert ignore dc change patch but with a fix for the idle-unidle loop
  - Change Idle/UnIdle condition evaluation

Issues: https://github.com/openshiftio/openshift.io/issues/4215