### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 87bf305c5d73a9cf4df5f37172aaf19d9e7034ea
+- hash: 44739f8c66bbe1473d5a91b4fd59fdbc2b265d18
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit uppdate.sh 87bf305c5d73a9cf4df5f37172aaf19d9e7034ea..44739f8c66bbe1473d5a91b4fd59fdbc2b265d18


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/11904c7e5c3ed1cab7bd0393c61fd62ff902a9cc
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-10T13:49:39+02:00

Assign number to new areas/iterations and allow searching by it (fabric8-services/fabric8-wit#2311)

Existing iterations and areas are not touched and won't have a number
assigned to them. This will come in a later change.

This is a code-only change to proof that it is backwards compatible.

See https://openshift.io/openshiftio/Openshift_io/plan/detail/618

Most of the code in this change comes from this PR which was later revered: https://github.com/fabric8-services/fabric8-wit/pull/2311

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/8674b7b56a9226b3bbd6ebf7b0179f127ff6a0a2
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-10T16:58:17+02:00

update number for existing iterations (fabric8-services/fabric8-wit#2314)

This updates all existing iterations and assigns a number to each iteration partitioned by space and in ascending order by creation time.

This change also makes the number a not-NULLable column on the iterations.

Also a constraint (`iterations_space_id_number_idx`) is created that ensures an iteration number can only occur once per iteration.

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/e67b5e2952f14903d2bca8b7e4e382565f8139a9
**Author:** nurali-techie (nurali.techie@gmail.com)
**Date:** 2018-10-15T14:00:33+05:30

stop calling analytics api for cve scan reg/de-reg (fabric8-services/fabric8-wit#2316)

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/37a913a9d9b409feb301adecdb35841a8ccfe127
**Author:** Baiju Muthukadan (baiju.m.mail@gmail.com)
**Date:** 2018-10-15T17:07:20+05:30

Include fabric8-common as a dependency (fabric8-services/fabric8-wit#2318)

- Replace id package

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/e09b8055ac7cff0ad32e12a3fe361888666bbbc9
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-15T14:44:35+02:00

Use Postgres CTE to update iteration numbers (fabric8-services/fabric8-wit#2319)

Use Postgres CTE to update iteration numbers

When explaining the updae before it looks like this:

```
postgres@172:postgres> explain UPDATE iterations iter SET number = seq.row_number
                       FROM (
                           SELECT id, space_id, created_at, row_number() OVER (PARTITION BY space_id ORDER BY created_at ASC)
                           FROM iterations
                       ) AS seq
                       WHERE iter.space_id = seq.space_id AND iter.id = seq.id;
+-----------------------------------------------------------------------------------------+
| QUERY PLAN                                                                              |
|-----------------------------------------------------------------------------------------|
| Update on iterations iter  (cost=2.06..2.16 rows=1 width=263)                           |
|   ->  Merge Join  (cost=2.06..2.16 rows=1 width=263)                                    |
|         Merge Cond: (seq.space_id = iter.space_id)                                      |
|         Join Filter: (iter.id = seq.id)                                                 |
|         ->  Subquery Scan on seq  (cost=1.03..1.09 rows=2 width=112)                    |
|               ->  WindowAgg  (cost=1.03..1.07 rows=2 width=48)                          |
|                     ->  Sort  (cost=1.03..1.03 rows=2 width=40)                         |
|                           Sort Key: iterations.space_id, iterations.created_at          |
|                           ->  Seq Scan on iterations  (cost=0.00..1.02 rows=2 width=40) |
|         ->  Sort  (cost=1.03..1.03 rows=2 width=187)                                    |
|               Sort Key: iter.space_id                                                   |
|               ->  Seq Scan on iterations iter  (cost=0.00..1.02 rows=2 width=187)       |
+-----------------------------------------------------------------------------------------+
```

Now the update looks better (notice absence of nested seq scans):

```
postgres@172:postgres> explain WITH iteration_numbers AS (
                           SELECT *, ROW_NUMBER() OVER(PARTITION BY space_id ORDER BY created_at ASC) AS num
                           FROM iterations
                       )
                       UPDATE iterations SET number = (SELECT num FROM iteration_numbers WHERE iteration_numbers.id = iterations.id);
+---------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                  |
|---------------------------------------------------------------------------------------------|
| Update on iterations  (cost=1.07..2.18 rows=2 width=191)                                    |
|   CTE iteration_numbers                                                                     |
|     ->  WindowAgg  (cost=1.03..1.07 rows=2 width=193)                                       |
|           ->  Sort  (cost=1.03..1.03 rows=2 width=185)                                      |
|                 Sort Key: iterations_1.space_id, iterations_1.created_at                    |
|                 ->  Seq Scan on iterations iterations_1  (cost=0.00..1.02 rows=2 width=185) |
|   ->  Seq Scan on iterations  (cost=0.00..1.11 rows=2 width=191)                            |
|         SubPlan 2                                                                           |
|           ->  CTE Scan on iteration_numbers  (cost=0.00..0.04 rows=1 width=8)               |
|                 Filter: (id = iterations.id)                                                |
+---------------------------------------------------------------------------------------------+
```

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/1724c15a0570ee14725370e08297f24ce56e1931
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-10-23T10:12:56+05:30

Rearrage search repository blackbox tests (fabric8-services/fabric8-wit#2322)

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/7fda6aff23aafbd17387f60422e4b40b097a2b78
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-10-23T13:49:11+05:30

Make agile default template for space creation (fabric8-services/fabric8-wit#2323)

The default template used for space creation will be `Agile`.

Rest of the changes are fixes to the tests which depended on the default template. I've changed them to use `fxt.WorkitemTypes` instead of `workitem.SystemFeature/workitem.SystemBug`

See https://github.com/fabric8-services/fabric8-wit/issues/2317 and https://github.com/openshiftio/openshift.io/issues/4427

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/7b78cf62bf3baa6c802304ac84d2c414334af6aa
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-23T11:54:01+02:00

Postpone iteration number update (fabric8-services/fabric8-wit#2325)

Currently the database migration 110 won't go through on prod-preview. I'm postponing it for now.

* Reverts "update number for existing iterations (fabric8-services/fabric8-wit#2314)"
   * This reverts commit 8674b7b56a9226b3bbd6ebf7b0179f127ff6a0a2.
* Revert "Use Postgres CTE to update iteration numbers (fabric8-services/fabric8-wit#2319)"
  * This reverts commit e09b8055ac7cff0ad32e12a3fe361888666bbbc9.

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/22e3d5dc39babb6c20f960191e952d82770c4a58
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2018-10-23T16:06:35+05:30

Enable the delete workitem endpoint (fabric8-services/fabric8-wit#2305)

Enables delete workitem endpoint

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/3d163c76989bac4f87396c9ff366b325711a52b0
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-10-23T17:45:11+05:30

Increase deployment timeout to 2X (fabric8-services/fabric8-wit#2327)

See https://github.com/fabric8-services/fabric8-wit/issues/2291

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/98798360355c333dbecbe80e373178f70587257b
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-10-24T11:30:20+05:30

Do not throw 500 on invalid value type in search API (fabric8-services/fabric8-wit#2321)

Fixes https://github.com/openshiftio/openshift.io/issues/4429

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/44739f8c66bbe1473d5a91b4fd59fdbc2b265d18
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-10-25T10:57:03+05:30

Remove redundant code and fix typo (fabric8-services/fabric8-wit#2329)

----