### PR TITLE
Update che plugin registry

### DIFF
--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e8d34d84b12468a6d077d205f52c63d72af5b9b4
+- hash: 717caabb38f38ea1ac5db83f294a9d8558ada0e1
   hash_length: 7
   name: che-plugin-registry
   path: /openshift/che-plugin-registry.yml


### PR DESCRIPTION
Changes

* 717caab 2018-11-05 | Change type of Eclipse Dirigible for Eclipse Che to Che Editor (#56) (HEAD -> master, origin/master) [Sergii Kabashniuk]
* 623ab9a 2018-11-05 | Adding dirigible-che-editor-plugin (#54) [Nedelcho Delchev]
* 17e5911 2018-10-24 | Added gwt based ide definition (#47) (dirigible) [Sergii Kabashniuk]