### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 44739f8c66bbe1473d5a91b4fd59fdbc2b265d18
+- hash: c81a4d2a6359a02231384bec89188f05930a18cf
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
This description was generated using this script:
```sh
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit changes.sh 44739f8c66bbe1473d5a91b4fd59fdbc2b265d18...c81a4d2a6359a02231384bec89188f05930a18cf

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/bbd8f88c789943293680644ae8a49b5342a55575
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-29T12:14:17+01:00

Add 'None' as default resolution for defect (fabric8-services/fabric8-wit#2334)

Add `None` to a Defect's resolution in the Agile space template and make it the default resolution by putting it in first place.

See https://github.com/openshiftio/openshift.io/issues/3832

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/d070588f2fe71c2eb71120655791c8a8aa8b070a
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-30T12:59:57+01:00

Fixup for bbd8f88c789943293680644ae8a49b5342a55575 fabric8-services/fabric8-wit#2334 (fabric8-services/fabric8-wit#2336)

Previously the [deployment failed](https://github.com/fabric8-services/fabric8-wit/pull/2334#issuecomment-433887438):

```
failed to overwrite default of old field type with None (string):
failed to set default value of enum type to None (string):
value: None (string) is not part of allowed enum values:
[Done Duplicate Incomplete Description Can not Reproduce Deferred Won't Fix Out of Date Verified]
file: spacetemplate/importer/repository.go
line: 91
```

We've updated the resolution enum to
have a new value and that is also the new default. That new value didn't
exist in the old enum type but we tried to make it the new default for
the old type anyways. That didn't work because the `FieldType.SetDefault()`
implementation for enums checks if the given value is part of the
allowed enum values.

The overall intention is to check if too enums are the same but ignore
the default value. That is why we temporarily make both defaults the
same before we call `FieldType.Equal()`.

With this change we simply reverse the assignment of the new default to
the old type. Instead we temporarily assign the old default to the new
type. The result is that a call to `FieldType.Equal()` will return true.

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/9dc1c08d14ba582ae68ba5e27551ab6262258043
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-10-30T15:53:19+01:00

Added .github/CODEOWNERS file (fabric8-services/fabric8-wit#2339)

We want to use this file in Github to automatically assign reviewers to PRs if they are declared as "owners".

Read more about this file here:

* https://blog.github.com/2017-07-06-introducing-code-owners/
* https://help.github.com/articles/about-codeowners/

So far I've added only "my" parts and the ones I feel deeply responsible for.

We can add more code owners later.

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/829eb51668989cef89fd2ceacc251cb2e7b46894
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-11-12T19:22:40+05:30

Rename SystemBoardColumns to BoardColumns in workitem relationships (fabric8-services/fabric8-wit#2345)

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/52056663d8fadbaa85425a9690f11e65acee7d24
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-11-13T10:16:37+01:00

capture range variable for parallel testing (fabric8-services/fabric8-wit#2346)

Before only the last range variable was being used and some tests just passed when the shouldn't have.

See also https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721.

And https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks for capturing range variables.

Thanks to @michaelkleinhenz for finding this and @jarifibrahim for finding the solution which is well known but in this case it is just too easy to miss.

----

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/c81a4d2a6359a02231384bec89188f05930a18cf
**Author:** Preeti Chandrashekar (preetipagad@gmail.com)
**Date:** 2018-11-17T16:34:10+05:30

Adds infotips for Work Items WIG (fabric8-services/fabric8-wit#2266)

----