### PR TITLE
chore: update fabric8 cluster to 53398f8

### DIFF
--- a/dsaas-services/f8-cluster.yaml
+++ b/dsaas-services/f8-cluster.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: edd01596bbe1dabf0f66b6dc431b4b88b35692b8
+- hash: 53398f8a7723bb6afe314afd2443d638138f6481
   name: fabric8-cluster
   path: /openshift/f8cluster.app.yaml
   url: https://github.com/fabric8-services/fabric8-cluster/


### PR DESCRIPTION
Update [fabric8-cluster](https://github.com/fabric8-services/fabric8-cluster)  to 53398f8a7723bb6afe314afd2443d638138f6481

cc @alexeykazakov 