### PR TITLE
Update wit on prod

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: c81a4d2a6359a02231384bec89188f05930a18cf
+- hash: d89ac3376facfd0d94c45c5162d37d6cba445ebb
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit prod-update.sh c81a4d2a6359a02231384bec89188f05930a18cf..d89ac3376facfd0d94c45c5162d37d6cba445ebb

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/539f671245af8cf253bdaec0b8a3ce38b6bc0f41
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-11-20T19:14:32+01:00

Link type descriptions (fabric8-services/fabric8-wit#2281)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/35506932bba65be9e1c03f60e4308e1d0cf72af6
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-11-23T14:40:19+01:00

Cleanup golden files comparison and generation by introducing compareOptions (fabric8-services/fabric8-wit#2354)

Before we used to have a list of booleans in order to configure the comparison and generation of golden files. Now we have a defined set of comparison options and a new compare function  compareWithGoldenOpts that let's you specify the options by hand.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/71f7cf3efd9f05b77d942060985b4dcbccf4b40f
**Author:** Michael Kleinhenz (kleinhenz@redhat.com)
**Date:** 2018-11-27T11:28:50+01:00

CSV Export (fabric8-services/fabric8-wit#2347)

This implements CSV export for work item query results. It provides a new endpoint `/search/workitems/csv` that takes the same parameters as the JSONAPI query endpoint and returns a CSV result.

Results from different types are squashed to one result CSV table with equal field labels unified across WITs. The WIT name is added in an extra column `_Type`. The underscore is used to make sure the type column does not clash with field columns.

See https://openshift.io/openshiftio/Openshift_io/plan/detail/40 for details on the story.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/1bdd0125c4829555465e6b40e36daa285ade52ff
**Author:** ckrych (corinnekrych@gmail.com)
**Date:** 2018-11-27T16:07:19+01:00

update README wit-cli instructions (fabric8-services/fabric8-wit#2356)

* update README wit-cli instructions

* Fix typo


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/d7fb836fbb4abd2f62d77299cae5fff1057ec43c
**Author:** Preeti Chandrashekar (preetipagad@gmail.com)
**Date:** 2018-11-28T10:44:07+05:30

Delete 'to be implemented' statement (fabric8-services/fabric8-wit#2353)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/f0437a54206587eced1e90b2eff43547864c779e
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2018-11-29T15:04:26+05:30

Trackerquery refactor (fabric8-services/fabric8-wit#2351)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/0999ce97b10ea89326d27290265dd0210e83012a
**Author:** Isaev Denis (idenx@yandex.com)
**Date:** 2018-11-29T18:05:14+03:00

add .golangci.yml (fabric8-services/fabric8-wit#2355)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/d89ac3376facfd0d94c45c5162d37d6cba445ebb
**Author:** Michael Kleinhenz (kleinhenz@redhat.com)
**Date:** 2018-12-03T13:02:50+01:00

CSV Streaming (fabric8-services/fabric8-wit#2359)

This updates the CSV export with a chunking/streaming implementation that allows for large CSVs to be returned to the client by incrementally retrieving and chunking output internally. There is no change on the client side and/or endpoint API, this change is just internally.

----