### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0286d1964597e726d30769de825a3e998bf2677d
+- hash: 363074e05d556c8ad1d2e00daf1dcc69d15fc9bc
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 654a84c3e fix(add-space-overlay): move the modal to add space overlay component. (#3429)
* 363074e05 fix(add-app-overlay): Change design of create an application modal (#3427)
* 86a2e6d7a fix(add-space-overlay): Change design of add space modal (#3421)
* 573c65e22 feat(roles): add role management using permission service (#3426)
* d3bc89f45 fix(rebranding): Update home page's empty state to use CodeReady Toolchain (OSIO-1120).
* 3764db9b9 fix(branding): Update Help link to "About CodeReady Toolchain" (OSIO-1119).
* 9f2ea31fa fix(rebranding): Update OSIO page title to CodeReady Toolchain (OSIO-1118) (#3422)
* 88f19e0c4 fix(package): upgrade npm-run-all to v4.1.5 (#3420)
* ab7cdb4b5 fix(package): downgrade stylelint to 9.6.0 and uglifyjs-webpack-plugin to 1.2.5
* f0b1ce568 feat(package): update fabric8-stack-analysis-ui to 2.1.1
* 0635dadf5 fix(test): clean up config for jest test now that libs are updated
* f184059a0 fix(package): downgrade bootstrap to 3.3.7 since v4 does not support LESS
* cd9971988 fix(package): downgrade jasmine to 3.2.0 and jasmine-core to 3.2.1
* 9576af42c feat(package): update library versions to latest