### PR TITLE
Upgrades idler: improves UserIdlerMap with concururrent safe map

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 808e55f578c4edb5993425162be01cdf6036dba8
+- hash: bdaaaae9537b79bb6ee7630b56ed3e3505a65be6
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
This patch fixes  collision happening which prevents
potential resource leaks and fixes data race conditions

*This patch could also fix a number of unidled pods seen recently 
where Jenkins deployments don't have jobs*

Includes:
 - https://github.com/fabric8-services/fabric8-jenkins-idler/pull/302

Fixes
 - https://github.com/fabric8-services/fabric8-jenkins-idler/issues/300