### PR TITLE
Updated docs for rebranding to CRT

### DIFF
--- a/dsaas-services/f8-docs.yaml
+++ b/dsaas-services/f8-docs.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: cc104c0219eb8b95cb5488620f0aa78958b0718c
+- hash: 21f0abab91669a3b546fd5a8223bc3c211d735a0
   name: fabric8-online-docs
   path: /openshift/fabric8-online-docs.app.yaml
   url: https://github.com/fabric8io/fabric8-online-docs


### PR DESCRIPTION
This updates docs landing page and all the guides for re-branding to CRT.