### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 07b0f5e7f9876bd4f909e3b44b77d1366f881f88
+- hash: 80a49072305398135ff3dc562192c959a1a19e54
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* 80a490723 fix(app-wizard-overlay): auto focus the input on modal open (#3442)
* 99992adcc fix(launcher-pipeline-service): remove the hardcoded argument `maven` from getPipeline method (#3441)
* ae20dafb4 fix(add-space-overlay): change Create Space and Exit button text to Create Empty Space and change create application icon (#3439)
* 37c71e8ee fix(ngx-launcher): upgrade ngx-launcher to 3.4.8 (#3436)
* 825525146 fix(add-app-overlay): enable next button if form is valid (#3437)
* e53e5c9c3 fix(spaces): fix save pin bug (#3438)