### PR TITLE
Updates f8-tenant: fixes plugin storage size issue and updates bayesian plugin (vb355188)

### DIFF
--- a/dsaas-services/f8-tenant.yaml
+++ b/dsaas-services/f8-tenant.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: a0f86aae313b1b16db7a8f7a3990bd5649f9ea6f
+- hash: 841000d30421a6cf412f2e76de28f01ce6809dde
   name: fabric8-tenant
   path: /OpenShiftTemplate.yml
   url: https://github.com/fabric8-services/fabric8-tenant/


### PR DESCRIPTION
This patch
- updates jenkins configuration to reduces the plugins storage
space required for each tenant jenkins. (fix#1)
- update bayesian jenkins plugin to 0.3.3 which has
enhancements to support osio-pipeline. (fix#2)

Updates f8-tenant image: vb355188

Fixes
    - openshiftio/openshift.io#4568
    - https://openshift.io/openshiftio/Openshift_io/plan/detail/1216