### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 80a49072305398135ff3dc562192c959a1a19e54
+- hash: bb87706496e7b238ff7777ec32f90266ed3e27d2
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* bb8770649 fix(dashboard): add hyperlinks to work item and codebase widgets (#3471)
* fe5d38e8a feat(deployments): remove the Deployments page
* 91cb8606a feat(application): remove the application / environment widget from the dashboard
* 2ef622e09 fix(pipelines): removes coupling of stack-report to stage name and updates test (#3470)
* 2d03efe84 fix(autofocus): add autofocus to iteration modal (#3466)
* 4a438950c fix(planner): Child work item inherits iteration (#3465)
* abf38e366 fix(planner): Iteration labels not used consistently #2997 (#3464)
* f8a9a5101 fix(style): width of the elements (#3463)
* ca7fa9ab1 fix(mission-runtime.service): add feature flag for nodejs booster (#3449)
* 1eb037417 fix(package): update the package-lock, remove lock from planner (#3462)
* 017cd1396 fix(home): open space creation modal from home page (#3452)
* 33f939703 fix(dashboard): Add tooltips icons on space dashboard #4294 (#3456)
* 7024ca7c1 fix(iteration): Add validation to create iteration form (#3451)
* 4f9201a75 (tag: v4.1.4) fix(format): update code with lint and prettier (#3461)
* e2ddde2d9 (tag: v4.1.3) fix(table-config): Set arrows as disabled when no column is selected (#3450)
* e7fe05758 (tag: v4.1.2) fix(planner): Moving tooltip on + of "iterations" in planner #3068 (#3460)
* 89733e1f2 chore(lint): clean up list of disabled eslint rules (#3459)
* 879a04f7b (tag: v4.1.1) fix(profile): disable profile update if bio char count increases max limit (#3457)
* 430f3a896 chore(lint): enable prettier on planner and fix up errors
* 9b98fada2 chore(lint): enable prettier on fabric8-ui and fix up errors
* a2d61cdb6 chore(lint): enable prettier on ngx-widgets and fix up errors
* 36b29039e chore(lint): enable lint on entire project but disable rules for planner and ngx-widgets
* f4d9ca2dc (tag: v4.1.0) fix(tests): run tests with CI=1 to ensure exit code is properly reported for failures (#3453)
* 1a4897a99 chore(tests): run all monorepo unit tests
* 245b7a1d9 feat(monorepo): update fabric8-ui to use planner and ngx-widgets from monorepo
* d7c73625b chore(ngx-widgets): update ngx-widgets to be referenced in monorepo
* 78cecdaa9 chore(planner): update planner to run tests in monorepo
* aaa8da2d6 chore(lerna): include all packages
* 0500a8598 chore(vscode): ignore .cache-loader dir in search
* 332c7bee2 (tag: v4.0.1) fix(lint): fix linting errors
* 2f689ec06 fix(ngx-widgets): update ngx-widgets to function in the monorepo
* 70dc6b95a fix(build): exclude planner and ngx-widget packages until they are fixed (#3446)
* f27149528 Add 'packages/planner/' from commit '01316bad7bb0d69ea38975838697a4187b4512c3'
* 1c41f7ee8 Add 'packages/ngx-widgets/' from commit 'b569e15fac75c5739d87b1c9a46216bb792c8d80'
* d7e5cf642 fix(build): run semantic-release from root and only include build dir (#3445)
* 9029f2512 feat(monorepo): Move to Monorepo (#3443)