### PR TITLE
Update fabric8-ui.yaml

### DIFF
--- a/dsaas-services/fabric8-ui.yaml
+++ b/dsaas-services/fabric8-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: b58f4196756f4fac8274b7a96e1bccd165042b81
+- hash: c0c1e654686963c48b58777982df8b3bdb53e64f
   name: fabric8-ui
   path: /openshift/fabric8-ui.app.yaml
   url: https://github.com/fabric8-ui/fabric8-ui/


### PR DESCRIPTION
* c0c1e6546 fix(api-url): add auth api url in openshift config map (#3519)
* 18429cb43 fix(preview): Markdown component layout breaks on copy-paste (#3510)
* 34e3bbd72 fix(launcher): upgrade ngx-launcher to 3.4.23 (#3517)
* 1c02d2b0f fix(navigation): page content does not refresh in new navigation (#3518)
* 0a6c91a7d fix(deployment): `resources` user settings link returns 404 error page (#3516)
* d27f57376 chore(scripts): temporary npm scripts removed (#3515)
* c871524a8 feat(logout): new logout implementation using /logout/v2 API (#3513)
* 6d5ccf232 feat(widgets): rename widgets to react-widgets and add new package angular-widgets (#3512)
* 66fa2369f chore(runtime+scripts):planner dead code removal (#3501)
* 54bf18127 feat(deployment): remove wit deployment api calls (#3502)
* b19e4ab31 fix(recommender): updates version of ngx-fabric8-wit (#3508)
* 1afe571f4 chore(scope): Moved to talamer namespace for scripts and widgets package (#3507)
* 7a1ddad38 fix(env): assign wit url to feature toggles and add fallback to /api/ (#3505)
* 196e68d16 Add gitignore for package-lock.json inside packages (#3506)
* dd75ecd45 fix(middleware): install localStorage and redirect middlewares
* 9850d0db4 test(react): add react unit tests
* c74055e18 feat(middleware): add redirect middleware
* bbee5c815 feat(middleware): add localstorage middleware
* 24744f345 fix(apiurl): use Fabric8UIEnv for api urls w/ a fallback to process.env
* c1e1356a4 fix(dashboard): Add Iteration options are showing enabled for a non-collaborator (#3495)
* 933749881 fix(mission-runtime): add feature flag for golang booster (#3498)
* 81634866b fix(planner): description does not change when selecting a new one (#3500)
* 388d98152 fix(navigation): fix space navigation to return to root for 'All Spaces' in overview (#3494)
* a76b8a760 fix(Iteration): Iteration show active on the last and first day of month (#3496)
* b4b98356e fix(nav): set feature toggle api url in env to wit url (#3497)
* db506abb3 fix(detector): remove extra / from build tool detector url (#3490)
* afab1dfdc fix(loading_state): Add test cases for home component (#3493)
* d7475e9bd fix(apiurl): fix feature toggle api url and add fallback url (#3492)
* 09e32b80c feat(nav): update builds to point to packages/toolchain (#3482)
* 042a383a3 fix(launcher): upgrade ngx-launcher to 3.4.19
* a7d8e5e78 fix(loading_state): change user fetching to observable in home component (#3491)
* d98c97d2e fix(deployment): Use Build Tool Detector URL from config map (#3488)
* a6d1ed562 fix(test): add missing test change (#3487)
* c4319cc56 fix(cache): increase cache TTL to 5000
* 386d41402 fix(toolchain): add FABRIC8_BUILD_TOOL_DETECTOR_API_URL in toolchain env (#3485)
* ee45b1b9c fix(detector): FABRIC8_BUILD_TOOL_DETECTOR_API_URL url (#3484)
* 79a65399d fix(scripts): replace http-server with serve (#3483)
* 427aae9ab feat(feature-toggle): resolve feature flags on component level (#3467)
* 3637dba5f fix(launcher): add env param - fabric8_build_tool_detector_api_url (#3481)
* 937044355 fix(app-launcher): add service for build tool detection (#3476)
* bfd06f8ee new application with react and pf4 support (#3478)
* a05261686 fix(add-app-overlay): update the error message (#3480)
* d2c4e43b3 fix(buildconfig): replace Openshit.io with codeReady Toolchain in pipeline confirm delete dailog (#3479)
* 01bfae99a fix(style): remove negative margin which caused tab to be clipped
* 94fc597da fix(tooltips): remove redundant tool tooltips which add zero value
* 27fd23c64 fix(styles): move styles to app.module because styles belong to the app, not the loader
* 79783f6db fix(webpack): add additional patternfly path locations and include the tsconfig from the app dir for type checking
* 15bfecfc3 feat(typescript): support dynamic imports by using module `esnext` in tsconfig