### PR TITLE
Update core.yaml

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: d89ac3376facfd0d94c45c5162d37d6cba445ebb
+- hash: cf91483b2b36315cc1e2ffbeddb272cdb419ab01
   name: fabric8-wit
   path: /openshift/core.app.yaml
   url: https://github.com/fabric8-services/fabric8-wit/


### PR DESCRIPTION
# About
This description was generated using this script:
```sh
#!/bin/bash
set -e
GHORG=${GHORG:-fabric8-services}
GHREPO=${GHREPO:-fabric8-wit}
cat <<EOF
# About
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

# Changes
EOF
git log \
  --pretty="%n**Commit:** https://github.com/${GHORG}/${GHREPO}/commit/%H%n**Author:** %an (%ae)%n**Date:** %aI%n%n%s%n%n%b%n%n----%n" \
  --reverse ${@:1} \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g"
```
Invoked as:

    GHORG=fabric8-services GHREPO=fabric8-wit changes.sh d89ac3376facfd0d94c45c5162d37d6cba445ebb...cf91483b2b36315cc1e2ffbeddb272cdb419ab01

# Changes

**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/9784eeec96235cdca1dac48774b692ece3d7d704
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-12-05T14:27:24+01:00

Also add @fabric8-services/fabric8-wit-team to my ownership (fabric8-services/fabric8-wit#2364)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/6f27f8b50bb178a468839475f45d199c0d7602c6
**Author:** ckrych (corinnekrych@gmail.com)
**Date:** 2018-12-06T18:55:22+01:00

Do not run parallel integration test (fabric8-services/fabric8-wit#2368)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/58492e80b0ecf870132a7b6360272392c245a62a
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-12-10T17:15:44+05:30

Add GO_TEST_BINARIES_PARALLEL_FLAG to test-package function (fabric8-services/fabric8-wit#2370)

fixes https://github.com/fabric8-services/fabric8-wit/pull/2368#discussion_r240016216

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/ce0056800674ca481a55e60645200c7e4c266884
**Author:** ckrych (corinnekrych@gmail.com)
**Date:** 2018-12-10T14:31:24+01:00

API to obfuscate user details in the DB (fabric8-services/fabric8-wit#2358)

This API overwrites the user details with obfuscated strings - to be called using an Auth Service account only.

fixes https://openshift.io/openshiftio/Openshift_io/plan/detail/804

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/fe049a79f92f5a659342adf55dd1a10e5f16cf84
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2018-12-17T16:10:16+05:30

removes update trackerquery action (fabric8-services/fabric8-wit#2381)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/642359880f5d33b655539b4053d69e6c2ae4ca63
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-12-19T09:53:07+05:30

Use golang 1.9.4 from website (fabric8-services/fabric8-wit#2383)

1. go1.9.4 from website to run tests without coverage and build the binary
2. go1.11 from epel to run tests with coverage (we need go >= 1.10 because test cache was introduced in go 1.10)

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/4cf253ee89da86374a40a8737d2adea19c74e086
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-12-19T10:52:10+05:30

Use go1.9.4 to build the binary (fabric8-services/fabric8-wit#2384)

The cico_build_deploy.sh script did not set the USE_GO_VERSION_FROM_WEBSITE flag and because of that go1.11 was used from epel to build the binary (see build https://ci.centos.org/job/devtools-fabric8-wit-build-master/618/consoleFull) .

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/07910991597d35170a78bb697df3e79ef287abd9
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2018-12-19T15:01:24+05:30

Use only go1.9 for all builds (fabric8-services/fabric8-wit#2385)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/6c2caea5cbb58201531636f4ee5b66f6fbc1b0f7
**Author:** ckrych (corinnekrych@gmail.com)
**Date:** 2018-12-19T13:08:25+01:00

Add swagger_ui to macOS doker-compose (fabric8-services/fabric8-wit#2380)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/bfd2c3da5ad5302adb54a500fb7d2aca3a60a59b
**Author:** Konrad Kleine (193408+kwk@users.noreply.github.com)
**Date:** 2018-12-20T10:46:36+01:00

Add "system_remote_item_url" and "system_remote_tracker_id" WIT fields (fabric8-services/fabric8-wit#2366)

* Add KindRemoteTracker and two new planner item fields
* Declare KindRemoteTracker as simple type
* Relabel system_remote_item_url field

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/5c95c04e5c96fa7917ea5ae643dd61d67db34d82
**Author:** Michael Kleinhenz (kleinhenz@redhat.com)
**Date:** 2018-12-20T12:43:11+01:00

Parent-Child Relationships in CSV Export (fabric8-services/fabric8-wit#2372)

This adds A column `_Parent` and a column `_Childs` to the CSV export. The columns are added by default and contain the parent number and the child numbers (if any) of the Work Item represented by the corresponding line.

This implements https://openshift.io/openshiftio/Openshift_io/plan/detail/1147

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/ac1460f5361bfc10d7d0490e7931914e817af307
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2018-12-21T14:27:33+05:30

Adds WIT parameter in TrackerQuery payload (fabric8-services/fabric8-wit#2360)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/74531c726215ef077b2dff969a68225029a63a17
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2018-12-28T17:09:56+05:30

Add permissions to trackerqueries (fabric8-services/fabric8-wit#2382)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/f6f1d58cb7b27f96d0d5423c12dfec1e36342cd9
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-03T20:27:00+05:30

adds tests for delete trackerquery on controller level (fabric8-services/fabric8-wit#2388)

Adds missing tests for delete trackerquery on controller level.

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/74e6bd8ef27bba3bf74f52e95f3ac6f506e1d7b7
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-08T13:54:15+05:30

List all TrackerQueries for a space (fabric8-services/fabric8-wit#2387)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/6854cf0c4a87ebb21485154d8bd8de164b0cdea0
**Author:** Baiju Muthukadan (baiju.m.mail@gmail.com)
**Date:** 2019-01-14T12:09:54+05:30

Add remote item URL & tracker ID to WI (fabric8-services/fabric8-wit#2389)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/1d947400580ad8c9f4fc6fd3723807b0e7350a16
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-14T15:22:06+05:30

Test Fixture for Tracker Query (fabric8-services/fabric8-wit#2390)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/b30cc39b87e1f4adb03b5b14e5f10fa0533cf43f
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-14T18:53:10+05:30

refactor trackerquery controller level tests (fabric8-services/fabric8-wit#2391)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/04d74e129c736714ca89d4c200e8fa192c489390
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-14T21:27:59+05:30

Enables searching of workitems by trackerquery id (fabric8-services/fabric8-wit#2392)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/8c71948c400080fccab6e79b323af99053c6462c
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-16T11:38:10+05:30

Delete trackerquery (fabric8-services/fabric8-wit#2394)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/a9703fb7d85cbfa4e7a8f703a5fdfb5c252c1ae7
**Author:** ckrych (corinnekrych@gmail.com)
**Date:** 2019-01-21T14:28:10+01:00

Add Delete user API by username to be called by the auth service (fabric8-services/fabric8-wit#2386)

* Add Delete user API by username to be called by admin-console service account

* delete assocaited space owned by an identities being deleted

* Add Delete user API by username to be called by admin-console service account

* delete assocaited space owned by an identities being deleted

* Delete user ans associated resources should be called from auth service

* make codacy happy with coding styling

* Update account/user.go

Co-Authored-By: corinnekrych <corinnekrych@gmail.com>

* Update account/user.go

Co-Authored-By: corinnekrych <corinnekrych@gmail.com>

* clean code with review's comments

* Update account/user.go

Co-Authored-By: corinnekrych <corinnekrych@gmail.com>

* refactor delete user test in sub-test

* refactor delete user remove unnecessary tf.Users(1)

* refactor delete user remove to assert wuth CheckExists

* Update design/account.go

Co-Authored-By: corinnekrych <corinnekrych@gmail.com>

* Update space/space.go

Co-Authored-By: corinnekrych <corinnekrych@gmail.com>

* refactor space test to use nest sub-test

* refactor migration tests to use gorm.Dialect

* add test for deleting users with mutiple identities

* refactor account/user_blackbox_test.go to fail the sub-test instead of entire test

* refactor controller/users.go to group if statement

* refactor controller/users.go tests into subtest

* remove user should keep all data committed on spaces not owned by this user, whereas data in owned spaces are all deleted

* fix unit test for create wit revision, unknown modifier is allowed

* refactor

* refactor

* refactor

* PermanetDelete of a space to check for spaceId nil

* make codacy happy

* migration test to check modifier_id colunm is not dropped


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/e553514f1dd5d0e4f0086ae467af1fc6f89abfcf
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-21T20:10:44+05:30

Adds Space, WorkItemType, Tracker dependency in TrackerQuery test (fabric8-services/fabric8-wit#2399)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/874db201c19d3e4badb37d5ab62a12d6eb5b0269
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2019-01-22T15:22:52+05:30

Fix typo: entires => entries (fabric8-services/fabric8-wit#2398)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/587d0d29ce0d13e9c2c0edc3ef1816e8debb121a
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2019-01-22T18:12:15+05:30

Add support for system_* fields along with system.* fields (fabric8-services/fabric8-wit#2341)

* Rename system.* to system_* in a all files (fabric8-services/fabric8-wit#2330)

* Update branch osio-story-743-rename-fields (fabric8-services/fabric8-wit#2350)

* Add temporary code for field rename (fabric8-services/fabric8-wit#2333)

    * Add replaceFieldName and addFieldName with tests

    * Remove unnecessary log.Error from golden_files_test.go

    * Fix failing test in expression_compiler_blackbox_test.go

    * Skip FullTextSearch and iteration test until migrations are added

    * Add golden files with old and new field names

    * Add todo to skipped tests

    * Add foo.bar test for expression_compiler


* Update /workitemtype response for field rename (fabric8-services/fabric8-wit#2335)

    * Change workitemtype response payload

    * Update golden files related to workitemtype response change

* Add onField to the /workitem/event response (fabric8-services/fabric8-wit#2337)

    * Add event_name attribute to the event response

    * fix golden files related to workitem_event

    * Rename event_name to onField in event/show response

    * Update golden files

* Add migrations for field name rename (fabric8-services/fabric8-wit#2340)

    * Add migration for workitem_type field renames

    * Add field rename migrations for work_items and work_item_revisions table

* Enable skipped test for field rename and update TSV trigger (fabric8-services/fabric8-wit#2342)

    * Add migration for TSV vector and triggers for field renames

* Change migration file names


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/73cd088560a35e24e9fddb507a1472d43c69e211
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2019-01-23T17:30:26+05:30

Revert "Add support for system_* fields along with system.* fields (fabric8-services/fabric8-wit#2341)" (fabric8-services/fabric8-wit#2401)

This reverts commit 587d0d29ce0d13e9c2c0edc3ef1816e8debb121a.

Revert "Add support for system_* fields along with system.* fields (fabric8-services/fabric8-wit#2341)"
This reverts commit 587d0d29ce0d13e9c2c0edc3ef1816e8debb121a.

#2341 was merged but the `core-97` deployment was failing. This PR reverts the changes.

A possible reason for the deployment failure could be the huge database migration. The field rename PR updates **every row of 3 tables**. This is a database intensive operation and would take some amount of time to complete. But since it didn't complete within the timeout, openshift marks the pod as `unhealthy` and kills it. A new pod would come up and the same cycle would repeat.

Kibana logs - https://logs.dsaas-stg.openshift.com/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2019-01-22T12:50:00.000Z',mode:absolute,to:'2019-01-22T13:20:00.000Z'))&_a=(columns:!(_source),filters:!(),index:'project.dsaas-preview.6e520a9f-d097-11e8-9fb7-121499db9246.*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'kubernetes.labels.deployment:core-97')),sort:!('@timestamp',desc))

This shows the Kibana logs for the actual pod: [`kubernetes.pod_name:"core-97-6cjh9" AND kubernetes.namespace_name:"dsaas-preview"`](https://logs.dsaas-stg.openshift.com/app/kibana#/discover?_g=(time:(from:now-1w,mode:relative,to:now))&_a=(columns:!(kubernetes.container_name,message),index:'project.dsaas-preview.6e520a9f-d097-11e8-9fb7-121499db9246.*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'kubernetes.pod_name:%22core-97-6cjh9%22+AND+kubernetes.namespace_name:%22dsaas-preview%22')),sort:!('@timestamp',desc)))

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/6eeb10fa521787a5da138f9cee94dfef6f354550
**Author:** Dhriti Shikhar (dhriti.shikhar.rokz@gmail.com)
**Date:** 2019-01-25T15:40:57+05:30

Adds test for non existing tracker query in search (fabric8-services/fabric8-wit#2400)



----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/befa5bc0336d94d23802a4d6fa280e30ab5ef2cc
**Author:** Alexey Kazakov (alkazako@redhat.com)
**Date:** 2019-02-13T15:00:35-05:00

Proxy /logout/v2 to Auth service (fabric8-services/fabric8-wit#2403)

* Proxy /logout/v2 to Auth service

* Update golden files for endpoint/list controller


----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/f7b1641d891c194976363c4a74d1fe0b575491af
**Author:** Xavier Coulon (xcoulon@redhat.com)
**Date:** 2019-02-20T16:43:26+01:00

Add security constraint in design for user deletion and obfuscation (fabric8-services/fabric8-wit#2405)

Fixes fabric8-services/fabric8-wit#2404

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

----


**Commit:** https://github.com/fabric8-services/fabric8-wit/commit/cf91483b2b36315cc1e2ffbeddb272cdb419ab01
**Author:** Ibrahim Jarif (jarifibrahim@gmail.com)
**Date:** 2019-02-21T09:41:40+05:30

Delete workspaces: Don't rely on links in the list workspaces response (fabric8-services/fabric8-wit#2402)

The response for workspace list returned from che starter does not contain a delete link.
This PR removes the check for the delete link in the response payload.

----

