### PR TITLE
Fix idler: feature toggle impl issue

### DIFF
--- a/dsaas-services/f8-jenkins-idler.yaml
+++ b/dsaas-services/f8-jenkins-idler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 749b033973d8a669f5013ae221b1d2c7b1d0454a
+- hash: 814b2a2db26591cd1346dcf1882bf0f1cbbbf82a
   hash_length: 6
   name: fabric8-jenkins-idler
   path: /openshift/jenkins-idler.app.yaml


### PR DESCRIPTION
The recent change to idler configuration package to use viper ( [73d8f0e]
(https://github.com/fabric8-services/fabric8-jenkins-idler/commit/73d8f0ed6864d40905cd72747a517de59adababf) ) introduceda change (regression) that resulted in GetFixedUuids returning a
when the variable isn't set.

This meant that idler would always choose the FixedUUID toggle instead of using
the actual feature toggle service.

This patch fixes the issue by fixing GetFixedUuids to return empty slice
if the env var isn't set.

Fixes https://github.com/fabric8-services/fabric8-jenkins-idler/issues/333