### PR TITLE
Update version of che-plugin-registry

### DIFF
--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 11cf2e16c2851056c35fcf0d2ef365e26b7c507c
+- hash: 51c6af63639f1b2facf7d44108adfa0f9fbf0440
   hash_length: 7
   name: che-plugin-registry
   path: /openshift/che-plugin-registry.yml


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

This PR changes [hash value](https://github.com/eclipse/che-plugin-registry/commit/51c6af63639f1b2facf7d44108adfa0f9fbf0440) of the commit from `che-plugin-registry` to pick up next plugins:

- VS Code Go
- VS Code TypeScript
- VS Code Node Debug
- VS Code Java by Red Hat
- VS Code XML by Red Hat
- VS Code YAML by Red Hat

