### PR TITLE
Updated to latest list of  gaugeified aliases of rhche prometheus couters

### DIFF
--- a/dsaas-services/osd-monitor-poc.yaml
+++ b/dsaas-services/osd-monitor-poc.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 24de7a08610b4edddac85e4f507d20d5ce2d310d
+- hash: a06cd0f1a0d41d018901262f4fd4945e82e4b94f
   name: osd-monitor-poc
   path: /osd-monitor.yml
   url: https://github.com/redhat-developer/osd-monitor-poc/


### PR DESCRIPTION
Reference to https://github.com/redhat-developer/osd-monitor-poc/pull/46
Add users total: https://github.com/eclipse/che/pull/13001
Workspace start metrics: https://github.com/eclipse/che/pull/12859
Successfully started workspaces ratio: https://github.com/eclipse/che/pull/12852
JSON RPC metrics: https://github.com/eclipse/che/pull/12673