### PR TITLE
Update che plugin registry to 30118e3

### DIFF
--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: bec007a9c9fbb975b30622badc7d56c233035156
+- hash: 30118e3d03d0eb82c54bd2927af47f3046ab9d6d
   hash_length: 7
   name: che-plugin-registry
   path: /openshift/che-plugin-registry.yml

--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 30118e3d03d0eb82c54bd2927af47f3046ab9d6d
+- hash: 6f6b2b9610525924fa7f9bdc950c8f15bdf4270d
   hash_length: 7
   name: che-plugin-registry
   path: /openshift/che-plugin-registry.yml


### PR DESCRIPTION
Update che-plugin-registry to [6f6b2b9](https://github.com/eclipse/che-plugin-registry/commit/6f6b2b9610525924fa7f9bdc950c8f15bdf4270d) to add:
- Kubernetes Tooling Che Plugin v1.0.0
- OpenShift Connector Che Plugin v0.0.21
