### PR TITLE
Update che plugin registry

### DIFF
--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 6f6b2b9610525924fa7f9bdc950c8f15bdf4270d
+- hash: 7a7b9b134a3be3bdbdc6c71ec5eed28a9e6376b1
   hash_length: 7
   name: che-plugin-registry
   path: /openshift/che-plugin-registry.yml


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

Update che-plugin-registry to [7a7b9b](https://github.com/eclipse/che-plugin-registry/commit/7a7b9b134a3be3bdbdc6c71ec5eed28a9e6376b1) to add **redhat-java:0.45.0** plugin 

Related issue: https://github.com/eclipse/che/issues/13378