### PR TITLE
Deploy Che Devfile Registry

### DIFF
--- a/dsaas-services/che-devfile-registry.yaml
+++ b/dsaas-services/che-devfile-registry.yaml
@@ -1,0 +1,13 @@
+services:
+- hash: 314caebc5bd0cb8e26360a650b646a047bd8a048
+  hash_length: 7
+  name: che-devfile-registry
+  path: /deploy/openshift/che-devfile-registry.yaml
+  url: https://github.com/eclipse/che-devfile-registry
+  environments:
+  - name: staging
+    parameters:
+      IMAGE: quay.io/openshiftio/rhel-che-devfile-registry
+  - name: production
+    parameters:
+      IMAGE: quay.io/openshiftio/rhel-che-devfile-registry


### PR DESCRIPTION
This PR adds deployment for Che Devfile Registry.
It reuses the following template for deploying Che Devfile Registry on OpenShift https://github.com/eclipse/che-devfile-registry/blob/master/deploy/openshift/che-devfile-registry.yaml

The following version of Devfile Registry is used https://github.com/eclipse/che-devfile-registry/tree/314caebc5bd0cb8e26360a650b646a047bd8a048