### PR TITLE
Update admin-console to 776041

### DIFF
--- a/dsaas-services/admin-console.yaml
+++ b/dsaas-services/admin-console.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e18b57d952e4e1ebc666ecaf90bb79147a1aeb00
+- hash: 776041f33cd3932f0690adee0a382004ce951fe4
   name: admin-console
   path: /openshift/admin-console.app.yaml
   url: https://github.com/fabric8-services/admin-console/


### PR DESCRIPTION
Mount the `/api/auditlogs/users` controller to create the audit log upon user deactivations on `auth`.