### PR TITLE
Updating che.openshift.io to the latest '7.0.0-beta-5.0' upstream version

### DIFF
--- a/dsaas-services/rh-che6.yaml
+++ b/dsaas-services/rh-che6.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 86e1ca2e44ee331d343283254beaf119ec729891
+- hash: d4a8c3b36b2abd56258f9d3eb9fd8a8e69eedb90
   hash_length: 7
   name: rh-che6
   path: /openshift/rh-che.app.yaml


### PR DESCRIPTION
MR for plugin registry update to `v3` - https://gitlab.cee.redhat.com/service/app-interface/merge_requests/678 (merged already)