### PR TITLE
Update che-plugin-registry to use next che-machine-exec version

### DIFF
--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 9c87243cb229aa27ee4bd4158b137bc3f842090b
+- hash: 92c7499aeaa8030bf7f3e0dcab660007de028d00
   hash_length: 7
   name: che-plugin-registry
   path: /openshift/che-plugin-registry.yml


### PR DESCRIPTION
### Referenced issue:
Update che-plugin-registry to use "next" che-machine-exec version

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>