### PR TITLE
Updating Prometheus to the latest version on prod

### DIFF
--- a/dsaas-services/che-monitoring.yaml
+++ b/dsaas-services/che-monitoring.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 779dc32a961a4a748fe627f60f5eebdf1b0d5d9e
+- hash: f314d2cffdc0b211b901d3a8c1b506eabd104197
   hash_length: 7
   name: che-monitoring
   path: /openshift/che-monitoring.yaml

--- a/dsaas-services/che-monitoring.yaml
+++ b/dsaas-services/che-monitoring.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2a37f1f0b91f677312ce4bcf3b134e151b379147
+- hash: 779dc32a961a4a748fe627f60f5eebdf1b0d5d9e
   hash_length: 7
   name: che-monitoring
   path: /openshift/che-monitoring.yaml

--- a/dsaas-services/che-monitoring.yaml
+++ b/dsaas-services/che-monitoring.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 91889753e52d1054befc8b5ce7c37f879eff5d9d
+- hash: 2a37f1f0b91f677312ce4bcf3b134e151b379147
   hash_length: 7
   name: che-monitoring
   path: /openshift/che-monitoring.yaml


### PR DESCRIPTION
Promotion to prod is blocked by the https://jira.coreos.com/browse/APPSRE-848
Updating Prometheus to the latest version on prod:
 - increasing `storage.tsdb.retention.time` to 30 days
 - using re-create strategy - https://github.com/redhat-developer/che-monitoring/commit/183ee25da25410280bcf6d032cde18206cca9bde