### PR TITLE
Updating rh-che to the latest version on production

### DIFF
--- a/dsaas-services/rh-che6.yaml
+++ b/dsaas-services/rh-che6.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: c52d64dc9bf8836e7194b9a736d0ef27c7364694
+- hash: e77122720f116ba496d9c9975352375a11734d01
   hash_length: 7
   name: rh-che6
   path: /openshift/rh-che.app.yaml


### PR DESCRIPTION
The changes required for https://github.com/redhat-developer/rh-che/pull/1646 were not applied in dsaas / dsaas-stg cms.

Currently, cms have been updated with a new `CHE_WORKSPACE_POOL_EXACT__SIZE` entry on both dsaas and dsaas-stg and we need to re-deploy the rhche on production