### PR TITLE
[WIP] [DO NOT MERGE] Updating deployment path for che-plugin-registry

### DIFF
--- a/dsaas-services/che-plugin-registry.yaml
+++ b/dsaas-services/che-plugin-registry.yaml
@@ -2,7 +2,7 @@ services:
 - hash: b3cf8c6d47a2b39d69a9f7b28d4567e9dc6bc355
   hash_length: 7
   name: che-plugin-registry
-  path: /openshift/che-plugin-registry.yml
+  path: /deploy/openshift/che-plugin-registry.yml
   url: https://github.com/eclipse/che-plugin-registry
   environments:
   - name: staging


### PR DESCRIPTION
The new deployment path has been introduced in the https://github.com/eclipse/che-plugin-registry/pull/245