### PR TITLE
Updating rh-che to the latest version on producion

### DIFF
--- a/dsaas-services/rh-che6.yaml
+++ b/dsaas-services/rh-che6.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2d2c4c6b1ef7cd392780bcbec34a3f0fb6278719
+- hash: f06f903c028c33e3e2961787803c4a9f36a9c478
   hash_length: 7
   name: rh-che6
   path: /openshift/rh-che.app.yaml


### PR DESCRIPTION
Rollout update is required for updating env vars defined in the cm after https://github.com/redhat-developer/rh-che/pull/1673