### PR TITLE
Applying upstream configuration for 'CHE_CORE_JSONRPC' + dicreasing the memory limit from 4GB back to default 1GB

### DIFF
--- a/dsaas-services/rh-che6.yaml
+++ b/dsaas-services/rh-che6.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 4ee061b921ce21bd4e774ae86f67f8691da9f33e
+- hash: 63b580ec68782c79b31d86f5e7f4d3fc129f37c5
   hash_length: 7
   name: rh-che6
   path: /openshift/rh-che.app.yaml


### PR DESCRIPTION
Issue - https://github.com/redhat-developer/rh-che/issues/1337