### PR TITLE
Providing a hot-fix for didact plugin `DEVFILE_REGISTRY_URL` reference

### DIFF
--- a/dsaas-services/che-devfile-registry.yaml
+++ b/dsaas-services/che-devfile-registry.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 6a2bace5c1cc7f8715f6b3244e80cca1afe0fd1d
+- hash: 142d193013f91c9d04c9ae32fd18913f96fe9931
   hash_length: 7
   name: che-devfile-registry
   path: /deploy/openshift/che-devfile-registry.yaml


### PR DESCRIPTION
Related PR - https://github.com/eclipse/che-devfile-registry/pull/337